### PR TITLE
Update dependencies to latests versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
- - 8
+ - 10
 cache: yarn

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,97 @@
 			"resolved": "https://registry.npmjs.org/5to6-codemod/-/5to6-codemod-1.7.1.tgz",
 			"integrity": "sha512-Nako5nAiihHQbnto9sIfD8OD2NLCEeciQph5y3DxrhbNpzUCdidEDRp/9XoczYPEO0hroAK/oQrikOY64/sBzw==",
 			"requires": {
-				"jscodeshift": "0.3.32",
-				"lodash": "4.17.4",
-				"recast": "0.12.9"
+				"jscodeshift": "^0.3.28",
+				"lodash": "^4.17.4",
+				"recast": "^0.12.1"
+			},
+			"dependencies": {
+				"jscodeshift": {
+					"version": "0.3.32",
+					"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.3.32.tgz",
+					"integrity": "sha1-3s5etgLxY0DY2VTH+WrJB8UC6rs=",
+					"requires": {
+						"async": "^1.5.0",
+						"babel-core": "^5",
+						"babel-plugin-transform-flow-strip-types": "^6.8.0",
+						"babel-preset-es2015": "^6.9.0",
+						"babel-preset-stage-1": "^6.5.0",
+						"babel-register": "^6.9.0",
+						"babylon": "^6.17.3",
+						"colors": "^1.1.2",
+						"flow-parser": "^0.*",
+						"lodash": "^4.13.1",
+						"micromatch": "^2.3.7",
+						"node-dir": "0.1.8",
+						"nomnom": "^1.8.1",
+						"recast": "^0.12.5",
+						"temp": "^0.8.1",
+						"write-file-atomic": "^1.2.0"
+					}
+				}
+			}
+		},
+		"@babel/code-frame": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+			"integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "7.0.0-beta.51"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.0.0-beta.51",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+			"integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"abab": {
@@ -34,7 +122,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
 			"integrity": "sha1-/YJw9x+7SZawBPqIDuXUZXOnMb8=",
 			"requires": {
-				"acorn": "4.0.13"
+				"acorn": "^4.0.4"
 			}
 		},
 		"acorn-jsx": {
@@ -42,7 +130,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
 			"integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
 			"requires": {
-				"acorn": "3.3.0"
+				"acorn": "^3.0.4"
 			},
 			"dependencies": {
 				"acorn": {
@@ -57,8 +145,8 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
 			"integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
 			"requires": {
-				"co": "4.6.0",
-				"json-stable-stringify": "1.0.1"
+				"co": "^4.6.0",
+				"json-stable-stringify": "^1.0.1"
 			}
 		},
 		"ajv-keywords": {
@@ -71,9 +159,9 @@
 			"resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
 			"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 			"requires": {
-				"kind-of": "3.2.2",
-				"longest": "1.0.1",
-				"repeat-string": "1.6.1"
+				"kind-of": "^3.0.2",
+				"longest": "^1.0.1",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"alter": {
@@ -81,7 +169,7 @@
 			"resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
 			"integrity": "sha1-x1iICGF1cgNKrmJICvJrHU0cs80=",
 			"requires": {
-				"stable": "0.1.6"
+				"stable": "~0.1.3"
 			}
 		},
 		"amdefine": {
@@ -94,6 +182,14 @@
 			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
 			"integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
 		},
+		"ansi-gray": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+			"integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+			"requires": {
+				"ansi-wrap": "0.1.0"
+			}
+		},
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -104,19 +200,300 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
 			"integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
 		},
+		"ansi-wrap": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+			"integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+		},
 		"ansicolors": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
 			"integrity": "sha1-vgiVmQl7dKXJxKhKDNvNtivYeu8="
 		},
 		"anymatch": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-			"integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "2.3.11",
-				"normalize-path": "2.1.1"
+				"micromatch": "^3.1.4",
+				"normalize-path": "^2.1.1"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				}
 			}
 		},
 		"append-transform": {
@@ -124,7 +501,7 @@
 			"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"requires": {
-				"default-require-extensions": "1.0.0"
+				"default-require-extensions": "^1.0.0"
 			}
 		},
 		"argparse": {
@@ -132,7 +509,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
 			"integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			}
 		},
 		"arr-diff": {
@@ -140,13 +517,19 @@
 			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"requires": {
-				"arr-flatten": "1.1.0"
+				"arr-flatten": "^1.0.1"
 			}
 		},
 		"arr-flatten": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
 			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+		},
+		"arr-union": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+			"dev": true
 		},
 		"array-differ": {
 			"version": "1.0.0",
@@ -163,7 +546,7 @@
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"requires": {
-				"array-uniq": "1.0.3"
+				"array-uniq": "^1.0.1"
 			}
 		},
 		"array-uniq": {
@@ -191,15 +574,21 @@
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
 			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
+		"assign-symbols": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+			"dev": true
+		},
 		"ast-traverse": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz",
 			"integrity": "sha1-ac8rg4bxnc2hux4F1o/jWdiJfeY="
 		},
 		"ast-types": {
-			"version": "0.9.6",
-			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-			"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
+			"version": "0.11.5",
+			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
+			"integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw=="
 		},
 		"astral-regex": {
 			"version": "1.0.0",
@@ -212,10 +601,22 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
 			"integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
 		},
+		"async-limiter": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+			"integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+			"dev": true
+		},
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
 			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+		},
+		"atob": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+			"integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
+			"dev": true
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -232,9 +633,9 @@
 			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"requires": {
-				"chalk": "1.1.3",
-				"esutils": "2.0.2",
-				"js-tokens": "3.0.2"
+				"chalk": "^1.1.3",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.2"
 			},
 			"dependencies": {
 				"js-tokens": {
@@ -249,52 +650,52 @@
 			"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.38.tgz",
 			"integrity": "sha1-H8ruedfmG3ULALjlT238nQr4ZVg=",
 			"requires": {
-				"babel-plugin-constant-folding": "1.0.1",
-				"babel-plugin-dead-code-elimination": "1.0.2",
-				"babel-plugin-eval": "1.0.1",
-				"babel-plugin-inline-environment-variables": "1.0.1",
-				"babel-plugin-jscript": "1.0.4",
-				"babel-plugin-member-expression-literals": "1.0.1",
-				"babel-plugin-property-literals": "1.0.1",
-				"babel-plugin-proto-to-assign": "1.0.4",
-				"babel-plugin-react-constant-elements": "1.0.3",
-				"babel-plugin-react-display-name": "1.0.3",
-				"babel-plugin-remove-console": "1.0.1",
-				"babel-plugin-remove-debugger": "1.0.1",
-				"babel-plugin-runtime": "1.0.7",
-				"babel-plugin-undeclared-variables-check": "1.0.2",
-				"babel-plugin-undefined-to-void": "1.1.6",
-				"babylon": "5.8.38",
-				"bluebird": "2.11.0",
-				"chalk": "1.1.3",
-				"convert-source-map": "1.5.0",
-				"core-js": "1.2.7",
-				"debug": "2.6.9",
-				"detect-indent": "3.0.1",
-				"esutils": "2.0.2",
-				"fs-readdir-recursive": "0.1.2",
-				"globals": "6.4.1",
-				"home-or-tmp": "1.0.0",
-				"is-integer": "1.0.7",
+				"babel-plugin-constant-folding": "^1.0.1",
+				"babel-plugin-dead-code-elimination": "^1.0.2",
+				"babel-plugin-eval": "^1.0.1",
+				"babel-plugin-inline-environment-variables": "^1.0.1",
+				"babel-plugin-jscript": "^1.0.4",
+				"babel-plugin-member-expression-literals": "^1.0.1",
+				"babel-plugin-property-literals": "^1.0.1",
+				"babel-plugin-proto-to-assign": "^1.0.3",
+				"babel-plugin-react-constant-elements": "^1.0.3",
+				"babel-plugin-react-display-name": "^1.0.3",
+				"babel-plugin-remove-console": "^1.0.1",
+				"babel-plugin-remove-debugger": "^1.0.1",
+				"babel-plugin-runtime": "^1.0.7",
+				"babel-plugin-undeclared-variables-check": "^1.0.2",
+				"babel-plugin-undefined-to-void": "^1.1.6",
+				"babylon": "^5.8.38",
+				"bluebird": "^2.9.33",
+				"chalk": "^1.0.0",
+				"convert-source-map": "^1.1.0",
+				"core-js": "^1.0.0",
+				"debug": "^2.1.1",
+				"detect-indent": "^3.0.0",
+				"esutils": "^2.0.0",
+				"fs-readdir-recursive": "^0.1.0",
+				"globals": "^6.4.0",
+				"home-or-tmp": "^1.0.0",
+				"is-integer": "^1.0.4",
 				"js-tokens": "1.0.1",
-				"json5": "0.4.0",
-				"lodash": "3.10.1",
-				"minimatch": "2.0.10",
-				"output-file-sync": "1.1.2",
-				"path-exists": "1.0.0",
-				"path-is-absolute": "1.0.1",
-				"private": "0.1.8",
+				"json5": "^0.4.0",
+				"lodash": "^3.10.0",
+				"minimatch": "^2.0.3",
+				"output-file-sync": "^1.1.0",
+				"path-exists": "^1.0.0",
+				"path-is-absolute": "^1.0.0",
+				"private": "^0.1.6",
 				"regenerator": "0.8.40",
-				"regexpu": "1.3.0",
-				"repeating": "1.1.3",
-				"resolve": "1.5.0",
-				"shebang-regex": "1.0.0",
-				"slash": "1.0.0",
-				"source-map": "0.5.7",
-				"source-map-support": "0.2.10",
-				"to-fast-properties": "1.0.3",
-				"trim-right": "1.0.1",
-				"try-resolve": "1.0.1"
+				"regexpu": "^1.3.0",
+				"repeating": "^1.1.2",
+				"resolve": "^1.1.6",
+				"shebang-regex": "^1.0.0",
+				"slash": "^1.0.0",
+				"source-map": "^0.5.0",
+				"source-map-support": "^0.2.10",
+				"to-fast-properties": "^1.0.0",
+				"trim-right": "^1.0.0",
+				"try-resolve": "^1.0.0"
 			},
 			"dependencies": {
 				"babylon": {
@@ -314,11 +715,11 @@
 			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
 			"integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
 			"requires": {
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash.assign": "4.2.0",
-				"lodash.pickby": "4.6.0"
+				"babel-traverse": "^6.0.20",
+				"babel-types": "^6.0.19",
+				"babylon": "^6.0.18",
+				"lodash.assign": "^4.0.0",
+				"lodash.pickby": "^4.0.0"
 			}
 		},
 		"babel-generator": {
@@ -326,14 +727,14 @@
 			"resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
 			"integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
 			"requires": {
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"detect-indent": "4.0.0",
-				"jsesc": "1.3.0",
-				"lodash": "4.17.4",
-				"source-map": "0.5.7",
-				"trim-right": "1.0.1"
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"detect-indent": "^4.0.0",
+				"jsesc": "^1.3.0",
+				"lodash": "^4.17.4",
+				"source-map": "^0.5.6",
+				"trim-right": "^1.0.1"
 			},
 			"dependencies": {
 				"detect-indent": {
@@ -341,7 +742,7 @@
 					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
 					"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 					"requires": {
-						"repeating": "2.0.1"
+						"repeating": "^2.0.0"
 					}
 				},
 				"jsesc": {
@@ -354,7 +755,7 @@
 					"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 					"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 					"requires": {
-						"is-finite": "1.0.2"
+						"is-finite": "^1.0.0"
 					}
 				}
 			}
@@ -364,9 +765,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz",
 			"integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-builder-binary-assignment-operator-visitor": {
@@ -374,9 +775,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
 			"integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
 			"requires": {
-				"babel-helper-explode-assignable-expression": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-explode-assignable-expression": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-call-delegate": {
@@ -384,10 +785,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
 			"integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-define-map": {
@@ -395,10 +796,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
 			"integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-explode-assignable-expression": {
@@ -406,9 +807,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
 			"integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-explode-class": {
@@ -416,10 +817,10 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
 			"integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
 			"requires": {
-				"babel-helper-bindify-decorators": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-bindify-decorators": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-function-name": {
@@ -427,11 +828,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
 			"integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
 			"requires": {
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-get-function-arity": {
@@ -439,8 +840,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
 			"integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-hoist-variables": {
@@ -448,8 +849,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
 			"integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-optimise-call-expression": {
@@ -457,8 +858,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
 			"integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-regex": {
@@ -466,9 +867,9 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
 			"integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-helper-remap-async-to-generator": {
@@ -476,11 +877,11 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helper-replace-supers": {
@@ -488,12 +889,12 @@
 			"resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
 			"integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
 			"requires": {
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-helpers": {
@@ -501,8 +902,8 @@
 			"resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-jest": {
@@ -510,36 +911,41 @@
 			"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-15.0.0.tgz",
 			"integrity": "sha1-ap4uOZnyQTg9uaseLvZwRAHXQkI=",
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-plugin-istanbul": "2.0.3",
-				"babel-preset-jest": "15.0.0"
+				"babel-core": "^6.0.0",
+				"babel-plugin-istanbul": "^2.0.0",
+				"babel-preset-jest": "^15.0.0"
 			},
 			"dependencies": {
 				"babel-core": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-					"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-generator": "6.26.0",
-						"babel-helpers": "6.24.1",
-						"babel-messages": "6.23.0",
-						"babel-register": "6.26.0",
-						"babel-runtime": "6.26.0",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"convert-source-map": "1.5.0",
-						"debug": "2.6.9",
-						"json5": "0.5.1",
-						"lodash": "4.17.4",
-						"minimatch": "3.0.4",
-						"path-is-absolute": "1.0.1",
-						"private": "0.1.8",
-						"slash": "1.0.0",
-						"source-map": "0.5.7"
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
 					}
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 				},
 				"json5": {
 					"version": "0.5.1",
@@ -551,7 +957,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				}
 			}
@@ -561,7 +967,7 @@
 			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-check-es2015-constants": {
@@ -569,7 +975,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
 			"integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-constant-folding": {
@@ -597,10 +1003,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-2.0.3.tgz",
 			"integrity": "sha1-JmswS5EJYH1gdIR0OUZ2mC9mDfQ=",
 			"requires": {
-				"find-up": "1.1.2",
-				"istanbul-lib-instrument": "1.9.1",
-				"object-assign": "4.1.1",
-				"test-exclude": "2.1.3"
+				"find-up": "^1.1.2",
+				"istanbul-lib-instrument": "^1.1.4",
+				"object-assign": "^4.1.0",
+				"test-exclude": "^2.1.1"
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -628,7 +1034,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz",
 			"integrity": "sha1-xJ56/QL1d7xNoF6i3wAiUM980SM=",
 			"requires": {
-				"lodash": "3.10.1"
+				"lodash": "^3.9.3"
 			},
 			"dependencies": {
 				"lodash": {
@@ -723,9 +1129,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
 			"integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-generators": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-generators": "^6.5.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-async-to-generator": {
@@ -733,9 +1139,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
 			"integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
 			"requires": {
-				"babel-helper-remap-async-to-generator": "6.24.1",
-				"babel-plugin-syntax-async-functions": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-remap-async-to-generator": "^6.24.1",
+				"babel-plugin-syntax-async-functions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-class-constructor-call": {
@@ -743,9 +1149,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
 			"integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
 			"requires": {
-				"babel-plugin-syntax-class-constructor-call": "6.18.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-syntax-class-constructor-call": "^6.18.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-class-properties": {
@@ -753,10 +1159,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
 			"integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-plugin-syntax-class-properties": "6.13.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-plugin-syntax-class-properties": "^6.8.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-decorators": {
@@ -764,11 +1170,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
 			"integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
 			"requires": {
-				"babel-helper-explode-class": "6.24.1",
-				"babel-plugin-syntax-decorators": "6.13.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-explode-class": "^6.24.1",
+				"babel-plugin-syntax-decorators": "^6.13.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-arrow-functions": {
@@ -776,7 +1182,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
 			"integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoped-functions": {
@@ -784,7 +1190,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
 			"integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-block-scoping": {
@@ -792,11 +1198,11 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
 			"integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-plugin-transform-es2015-classes": {
@@ -804,15 +1210,15 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
 			"integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
 			"requires": {
-				"babel-helper-define-map": "6.26.0",
-				"babel-helper-function-name": "6.24.1",
-				"babel-helper-optimise-call-expression": "6.24.1",
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-define-map": "^6.24.1",
+				"babel-helper-function-name": "^6.24.1",
+				"babel-helper-optimise-call-expression": "^6.24.1",
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-computed-properties": {
@@ -820,8 +1226,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
 			"integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-destructuring": {
@@ -829,7 +1235,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
 			"integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-duplicate-keys": {
@@ -837,8 +1243,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
 			"integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-for-of": {
@@ -846,7 +1252,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
 			"integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-function-name": {
@@ -854,9 +1260,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
 			"integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
 			"requires": {
-				"babel-helper-function-name": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-function-name": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-literals": {
@@ -864,7 +1270,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
 			"integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-amd": {
@@ -872,9 +1278,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
 			"integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
 			"requires": {
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-commonjs": {
@@ -882,10 +1288,10 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
 			"integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
 			"requires": {
-				"babel-plugin-transform-strict-mode": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-plugin-transform-strict-mode": "^6.24.1",
+				"babel-runtime": "^6.26.0",
+				"babel-template": "^6.26.0",
+				"babel-types": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-systemjs": {
@@ -893,9 +1299,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
 			"integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
 			"requires": {
-				"babel-helper-hoist-variables": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-helper-hoist-variables": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-modules-umd": {
@@ -903,9 +1309,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
 			"integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
 			"requires": {
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0"
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-object-super": {
@@ -913,8 +1319,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
 			"integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
 			"requires": {
-				"babel-helper-replace-supers": "6.24.1",
-				"babel-runtime": "6.26.0"
+				"babel-helper-replace-supers": "^6.24.1",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-parameters": {
@@ -922,12 +1328,12 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
 			"integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
 			"requires": {
-				"babel-helper-call-delegate": "6.24.1",
-				"babel-helper-get-function-arity": "6.24.1",
-				"babel-runtime": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-call-delegate": "^6.24.1",
+				"babel-helper-get-function-arity": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-template": "^6.24.1",
+				"babel-traverse": "^6.24.1",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-shorthand-properties": {
@@ -935,8 +1341,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
 			"integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-spread": {
@@ -944,7 +1350,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
 			"integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-sticky-regex": {
@@ -952,9 +1358,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
 			"integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-transform-es2015-template-literals": {
@@ -962,7 +1368,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
 			"integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-typeof-symbol": {
@@ -970,7 +1376,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
 			"integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es2015-unicode-regex": {
@@ -978,9 +1384,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
 			"integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
 			"requires": {
-				"babel-helper-regex": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"regexpu-core": "2.0.0"
+				"babel-helper-regex": "^6.24.1",
+				"babel-runtime": "^6.22.0",
+				"regexpu-core": "^2.0.0"
 			}
 		},
 		"babel-plugin-transform-es3-member-expression-literals": {
@@ -988,7 +1394,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-member-expression-literals/-/babel-plugin-transform-es3-member-expression-literals-6.22.0.tgz",
 			"integrity": "sha1-cz00RPPsxBvvjtGmpOCWV7iWnrs=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-es3-property-literals": {
@@ -996,7 +1402,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-es3-property-literals/-/babel-plugin-transform-es3-property-literals-6.22.0.tgz",
 			"integrity": "sha1-sgeNWELiKr9A9z6M3pzTcRq9V1g=",
 			"requires": {
-				"babel-runtime": "6.26.0"
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-exponentiation-operator": {
@@ -1004,9 +1410,9 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
 			"integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
 			"requires": {
-				"babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-				"babel-plugin-syntax-exponentiation-operator": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+				"babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-export-extensions": {
@@ -1014,8 +1420,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
 			"integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
 			"requires": {
-				"babel-plugin-syntax-export-extensions": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-export-extensions": "^6.8.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-flow-strip-types": {
@@ -1023,8 +1429,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
 			"integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
 			"requires": {
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-flow": "^6.18.0",
+				"babel-runtime": "^6.22.0"
 			}
 		},
 		"babel-plugin-transform-object-rest-spread": {
@@ -1032,8 +1438,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz",
 			"integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"babel-runtime": "6.26.0"
+				"babel-plugin-syntax-object-rest-spread": "^6.8.0",
+				"babel-runtime": "^6.26.0"
 			}
 		},
 		"babel-plugin-transform-regenerator": {
@@ -1041,7 +1447,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
 			"integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
 			"requires": {
-				"regenerator-transform": "0.10.1"
+				"regenerator-transform": "^0.10.0"
 			}
 		},
 		"babel-plugin-transform-strict-mode": {
@@ -1049,8 +1455,8 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
 			"integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0"
+				"babel-runtime": "^6.22.0",
+				"babel-types": "^6.24.1"
 			}
 		},
 		"babel-plugin-undeclared-variables-check": {
@@ -1058,7 +1464,7 @@
 			"resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
 			"integrity": "sha1-XPGqU52BP/ZOmWQSkK9iCWX2Xe4=",
 			"requires": {
-				"leven": "1.0.2"
+				"leven": "^1.0.2"
 			}
 		},
 		"babel-plugin-undefined-to-void": {
@@ -1071,30 +1477,30 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
 			"integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-function-name": "6.24.1",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-amd": "6.24.1",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-				"babel-plugin-transform-es2015-modules-umd": "6.24.1",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-				"babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-				"babel-plugin-transform-regenerator": "6.26.0"
+				"babel-plugin-check-es2015-constants": "^6.22.0",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+				"babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+				"babel-plugin-transform-es2015-classes": "^6.24.1",
+				"babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-destructuring": "^6.22.0",
+				"babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+				"babel-plugin-transform-es2015-for-of": "^6.22.0",
+				"babel-plugin-transform-es2015-function-name": "^6.24.1",
+				"babel-plugin-transform-es2015-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+				"babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+				"babel-plugin-transform-es2015-object-super": "^6.24.1",
+				"babel-plugin-transform-es2015-parameters": "^6.24.1",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+				"babel-plugin-transform-es2015-spread": "^6.22.0",
+				"babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+				"babel-plugin-transform-es2015-template-literals": "^6.22.0",
+				"babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+				"babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+				"babel-plugin-transform-regenerator": "^6.24.1"
 			}
 		},
 		"babel-preset-fbjs": {
@@ -1102,30 +1508,30 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-fbjs/-/babel-preset-fbjs-1.0.0.tgz",
 			"integrity": "sha1-yXLlybMB1OyeeXH0rsPhSsAXqLA=",
 			"requires": {
-				"babel-plugin-check-es2015-constants": "6.22.0",
-				"babel-plugin-syntax-flow": "6.18.0",
-				"babel-plugin-syntax-object-rest-spread": "6.13.0",
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-class-properties": "6.24.1",
-				"babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-				"babel-plugin-transform-es2015-block-scoping": "6.26.0",
-				"babel-plugin-transform-es2015-classes": "6.24.1",
-				"babel-plugin-transform-es2015-computed-properties": "6.24.1",
-				"babel-plugin-transform-es2015-destructuring": "6.23.0",
-				"babel-plugin-transform-es2015-for-of": "6.23.0",
-				"babel-plugin-transform-es2015-literals": "6.22.0",
-				"babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-				"babel-plugin-transform-es2015-object-super": "6.24.1",
-				"babel-plugin-transform-es2015-parameters": "6.24.1",
-				"babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-				"babel-plugin-transform-es2015-spread": "6.22.0",
-				"babel-plugin-transform-es2015-template-literals": "6.22.0",
-				"babel-plugin-transform-es3-member-expression-literals": "6.22.0",
-				"babel-plugin-transform-es3-property-literals": "6.22.0",
-				"babel-plugin-transform-flow-strip-types": "6.22.0",
-				"babel-plugin-transform-object-rest-spread": "6.26.0",
-				"object-assign": "4.1.1"
+				"babel-plugin-check-es2015-constants": "^6.7.2",
+				"babel-plugin-syntax-flow": "^6.5.0",
+				"babel-plugin-syntax-object-rest-spread": "^6.5.0",
+				"babel-plugin-syntax-trailing-function-commas": "^6.5.0",
+				"babel-plugin-transform-class-properties": "^6.6.0",
+				"babel-plugin-transform-es2015-arrow-functions": "^6.5.2",
+				"babel-plugin-transform-es2015-block-scoped-functions": "^6.6.5",
+				"babel-plugin-transform-es2015-block-scoping": "^6.7.1",
+				"babel-plugin-transform-es2015-classes": "^6.6.5",
+				"babel-plugin-transform-es2015-computed-properties": "^6.6.5",
+				"babel-plugin-transform-es2015-destructuring": "^6.6.5",
+				"babel-plugin-transform-es2015-for-of": "^6.6.0",
+				"babel-plugin-transform-es2015-literals": "^6.5.0",
+				"babel-plugin-transform-es2015-modules-commonjs": "^6.7.0",
+				"babel-plugin-transform-es2015-object-super": "^6.6.5",
+				"babel-plugin-transform-es2015-parameters": "^6.7.0",
+				"babel-plugin-transform-es2015-shorthand-properties": "^6.5.0",
+				"babel-plugin-transform-es2015-spread": "^6.6.5",
+				"babel-plugin-transform-es2015-template-literals": "^6.6.5",
+				"babel-plugin-transform-es3-member-expression-literals": "^6.5.0",
+				"babel-plugin-transform-es3-property-literals": "^6.5.0",
+				"babel-plugin-transform-flow-strip-types": "^6.7.0",
+				"babel-plugin-transform-object-rest-spread": "^6.6.5",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"babel-preset-jest": {
@@ -1133,7 +1539,7 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-15.0.0.tgz",
 			"integrity": "sha1-8jmI8fkYZz/5tHD9/WD8wZvGGPU=",
 			"requires": {
-				"babel-plugin-jest-hoist": "15.0.0"
+				"babel-plugin-jest-hoist": "^15.0.0"
 			}
 		},
 		"babel-preset-stage-1": {
@@ -1141,9 +1547,9 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
 			"integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
 			"requires": {
-				"babel-plugin-transform-class-constructor-call": "6.24.1",
-				"babel-plugin-transform-export-extensions": "6.22.0",
-				"babel-preset-stage-2": "6.24.1"
+				"babel-plugin-transform-class-constructor-call": "^6.24.1",
+				"babel-plugin-transform-export-extensions": "^6.22.0",
+				"babel-preset-stage-2": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-2": {
@@ -1151,10 +1557,10 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
 			"integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
 			"requires": {
-				"babel-plugin-syntax-dynamic-import": "6.18.0",
-				"babel-plugin-transform-class-properties": "6.24.1",
-				"babel-plugin-transform-decorators": "6.24.1",
-				"babel-preset-stage-3": "6.24.1"
+				"babel-plugin-syntax-dynamic-import": "^6.18.0",
+				"babel-plugin-transform-class-properties": "^6.24.1",
+				"babel-plugin-transform-decorators": "^6.24.1",
+				"babel-preset-stage-3": "^6.24.1"
 			}
 		},
 		"babel-preset-stage-3": {
@@ -1162,11 +1568,11 @@
 			"resolved": "https://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
 			"integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
 			"requires": {
-				"babel-plugin-syntax-trailing-function-commas": "6.22.0",
-				"babel-plugin-transform-async-generator-functions": "6.24.1",
-				"babel-plugin-transform-async-to-generator": "6.24.1",
-				"babel-plugin-transform-exponentiation-operator": "6.24.1",
-				"babel-plugin-transform-object-rest-spread": "6.26.0"
+				"babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+				"babel-plugin-transform-async-generator-functions": "^6.24.1",
+				"babel-plugin-transform-async-to-generator": "^6.24.1",
+				"babel-plugin-transform-exponentiation-operator": "^6.24.1",
+				"babel-plugin-transform-object-rest-spread": "^6.22.0"
 			}
 		},
 		"babel-register": {
@@ -1174,13 +1580,13 @@
 			"resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-runtime": "6.26.0",
-				"core-js": "2.5.1",
-				"home-or-tmp": "2.0.0",
-				"lodash": "4.17.4",
-				"mkdirp": "0.5.1",
-				"source-map-support": "0.4.18"
+				"babel-core": "^6.26.0",
+				"babel-runtime": "^6.26.0",
+				"core-js": "^2.5.0",
+				"home-or-tmp": "^2.0.0",
+				"lodash": "^4.17.4",
+				"mkdirp": "^0.5.1",
+				"source-map-support": "^0.4.15"
 			},
 			"dependencies": {
 				"babel-core": {
@@ -1188,25 +1594,25 @@
 					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
 					"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-generator": "6.26.0",
-						"babel-helpers": "6.24.1",
-						"babel-messages": "6.23.0",
-						"babel-register": "6.26.0",
-						"babel-runtime": "6.26.0",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"convert-source-map": "1.5.0",
-						"debug": "2.6.9",
-						"json5": "0.5.1",
-						"lodash": "4.17.4",
-						"minimatch": "3.0.4",
-						"path-is-absolute": "1.0.1",
-						"private": "0.1.8",
-						"slash": "1.0.0",
-						"source-map": "0.5.7"
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.0",
+						"debug": "^2.6.8",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.7",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.6"
 					}
 				},
 				"core-js": {
@@ -1219,8 +1625,8 @@
 					"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
 					"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.1"
 					}
 				},
 				"json5": {
@@ -1233,7 +1639,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"source-map-support": {
@@ -1241,7 +1647,7 @@
 					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"requires": {
-						"source-map": "0.5.7"
+						"source-map": "^0.5.6"
 					}
 				}
 			}
@@ -1251,8 +1657,8 @@
 			"resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"requires": {
-				"core-js": "2.5.1",
-				"regenerator-runtime": "0.11.0"
+				"core-js": "^2.4.0",
+				"regenerator-runtime": "^0.11.0"
 			},
 			"dependencies": {
 				"core-js": {
@@ -1267,11 +1673,11 @@
 			"resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"lodash": "4.17.4"
+				"babel-runtime": "^6.26.0",
+				"babel-traverse": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"lodash": "^4.17.4"
 			}
 		},
 		"babel-traverse": {
@@ -1279,15 +1685,15 @@
 			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"requires": {
-				"babel-code-frame": "6.26.0",
-				"babel-messages": "6.23.0",
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"debug": "2.6.9",
-				"globals": "9.18.0",
-				"invariant": "2.2.2",
-				"lodash": "4.17.4"
+				"babel-code-frame": "^6.26.0",
+				"babel-messages": "^6.23.0",
+				"babel-runtime": "^6.26.0",
+				"babel-types": "^6.26.0",
+				"babylon": "^6.18.0",
+				"debug": "^2.6.8",
+				"globals": "^9.18.0",
+				"invariant": "^2.2.2",
+				"lodash": "^4.17.4"
 			},
 			"dependencies": {
 				"globals": {
@@ -1302,10 +1708,10 @@
 			"resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"esutils": "2.0.2",
-				"lodash": "4.17.4",
-				"to-fast-properties": "1.0.3"
+				"babel-runtime": "^6.26.0",
+				"esutils": "^2.0.2",
+				"lodash": "^4.17.4",
+				"to-fast-properties": "^1.0.3"
 			}
 		},
 		"babylon": {
@@ -1318,13 +1724,80 @@
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
 		},
+		"base": {
+			"version": "0.11.2",
+			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
+			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+			"dev": true,
+			"requires": {
+				"cache-base": "^1.0.1",
+				"class-utils": "^0.3.5",
+				"component-emitter": "^1.2.1",
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.1",
+				"mixin-deep": "^1.2.0",
+				"pascalcase": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
+		},
 		"bcrypt-pbkdf": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
 			"integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
 			"optional": true,
 			"requires": {
-				"tweetnacl": "0.14.5"
+				"tweetnacl": "^0.14.3"
 			}
 		},
 		"beeper": {
@@ -1342,7 +1815,7 @@
 			"resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
 			"integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.x.x"
 			}
 		},
 		"brace-expansion": {
@@ -1350,7 +1823,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
 			"integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -1359,15 +1832,21 @@
 			"resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"requires": {
-				"expand-range": "1.8.2",
-				"preserve": "0.2.0",
-				"repeat-element": "1.1.2"
+				"expand-range": "^1.8.1",
+				"preserve": "^0.2.0",
+				"repeat-element": "^1.1.2"
 			}
 		},
 		"breakable": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz",
 			"integrity": "sha1-eEp5eRWjjq0nutRWtVcstLuqeME="
+		},
+		"browser-process-hrtime": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz",
+			"integrity": "sha1-Ql1opY00R/AqBKqJQYf86K+Le44=",
+			"dev": true
 		},
 		"browser-resolve": {
 			"version": "1.11.2",
@@ -1389,20 +1868,50 @@
 			"resolved": "https://registry.npmjs.org/bser/-/bser-1.0.2.tgz",
 			"integrity": "sha1-OBEWlwsqbe6lZG3RXdcnhES1YWk=",
 			"requires": {
-				"node-int64": "0.4.0"
+				"node-int64": "^0.4.0"
 			}
+		},
+		"buffer-from": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+			"integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ=="
 		},
 		"builtin-modules": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
 			"integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
 		},
+		"cache-base": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
+			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+			"dev": true,
+			"requires": {
+				"collection-visit": "^1.0.0",
+				"component-emitter": "^1.2.1",
+				"get-value": "^2.0.6",
+				"has-value": "^1.0.0",
+				"isobject": "^3.0.1",
+				"set-value": "^2.0.0",
+				"to-object-path": "^0.3.0",
+				"union-value": "^1.0.0",
+				"unset-value": "^1.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
+		},
 		"caller-path": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
 			"integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
 			"requires": {
-				"callsites": "0.2.0"
+				"callsites": "^0.2.0"
 			}
 		},
 		"callsites": {
@@ -1415,13 +1924,22 @@
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
 			"integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
 		},
+		"capture-exit": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
+			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
+			"dev": true,
+			"requires": {
+				"rsvp": "^3.3.3"
+			}
+		},
 		"cardinal": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/cardinal/-/cardinal-1.0.0.tgz",
 			"integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
 			"requires": {
-				"ansicolors": "0.2.1",
-				"redeyed": "1.0.1"
+				"ansicolors": "~0.2.1",
+				"redeyed": "~1.0.0"
 			}
 		},
 		"caseless": {
@@ -1434,8 +1952,8 @@
 			"resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
 			"integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
 			"requires": {
-				"align-text": "0.1.4",
-				"lazy-cache": "1.0.4"
+				"align-text": "^0.1.3",
+				"lazy-cache": "^1.0.3"
 			}
 		},
 		"chalk": {
@@ -1443,11 +1961,11 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
 			"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 			"requires": {
-				"ansi-styles": "2.2.1",
-				"escape-string-regexp": "1.0.5",
-				"has-ansi": "2.0.0",
-				"strip-ansi": "3.0.1",
-				"supports-color": "2.0.0"
+				"ansi-styles": "^2.2.1",
+				"escape-string-regexp": "^1.0.2",
+				"has-ansi": "^2.0.0",
+				"strip-ansi": "^3.0.0",
+				"supports-color": "^2.0.0"
 			}
 		},
 		"ci-info": {
@@ -1460,12 +1978,41 @@
 			"resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
 			"integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
 		},
+		"class-utils": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
+			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"define-property": "^0.2.5",
+				"isobject": "^3.0.0",
+				"static-extend": "^0.1.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
+		},
 		"cli-cursor": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 			"requires": {
-				"restore-cursor": "1.0.1"
+				"restore-cursor": "^1.0.1"
 			}
 		},
 		"cli-table": {
@@ -1484,12 +2031,12 @@
 			}
 		},
 		"cli-usage": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.4.tgz",
-			"integrity": "sha1-fAHg3HBsI0s5yTODjI4gshdXduI=",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/cli-usage/-/cli-usage-0.1.7.tgz",
+			"integrity": "sha512-x/Q52iLSZsRrRb2ePmTsVYXrGcrPQ8G4yRAY7QpMlumxAfPVrnDOH2X6Z5s8qsAX7AA7YuIi8AXFrvH0wWEesA==",
 			"requires": {
-				"marked": "0.3.6",
-				"marked-terminal": "1.7.0"
+				"marked": "^0.3.12",
+				"marked-terminal": "^2.0.0"
 			}
 		},
 		"cli-width": {
@@ -1502,20 +2049,26 @@
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
 			"integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
 			"requires": {
-				"center-align": "0.1.3",
-				"right-align": "0.1.3",
+				"center-align": "^0.1.1",
+				"right-align": "^0.1.1",
 				"wordwrap": "0.0.2"
 			}
 		},
 		"clone": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-			"integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+			"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
 		},
 		"clone-stats": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
 			"integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
+		},
+		"clorox": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/clorox/-/clorox-1.0.3.tgz",
+			"integrity": "sha512-w3gKAUKMJYmmaJyc+p+iDrDtLvsFasrx/y6/zWo2U1TZfsz3y4Vl4T9PHCZrOwk1eMTOSRI6xHdpDR4PhTdy8Q==",
+			"dev": true
 		},
 		"co": {
 			"version": "4.6.0",
@@ -1527,55 +2080,75 @@
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
-		"color-convert": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+		"collection-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
+			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"color-name": "1.1.3"
+				"map-visit": "^1.0.0",
+				"object-visit": "^1.0.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+			"integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.1"
 			}
 		},
 		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
 			"dev": true
 		},
+		"color-support": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+			"integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
+		},
 		"colors": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-			"integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+			"integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw=="
 		},
 		"combined-stream": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
 			"integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
 			"requires": {
-				"delayed-stream": "1.0.0"
+				"delayed-stream": "~1.0.0"
 			}
 		},
 		"commander": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-			"integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+			"version": "2.15.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+			"integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
 		},
 		"commoner": {
 			"version": "0.10.8",
 			"resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
 			"integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
 			"requires": {
-				"commander": "2.11.0",
-				"detective": "4.5.0",
-				"glob": "5.0.15",
-				"graceful-fs": "4.1.11",
-				"iconv-lite": "0.4.19",
-				"mkdirp": "0.5.1",
-				"private": "0.1.8",
-				"q": "1.5.1",
-				"recast": "0.11.23"
+				"commander": "^2.5.0",
+				"detective": "^4.3.1",
+				"glob": "^5.0.15",
+				"graceful-fs": "^4.1.2",
+				"iconv-lite": "^0.4.5",
+				"mkdirp": "^0.5.0",
+				"private": "^0.1.6",
+				"q": "^1.1.2",
+				"recast": "^0.11.17"
 			},
 			"dependencies": {
+				"ast-types": {
+					"version": "0.9.6",
+					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
+					"integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
+				},
 				"esprima": {
 					"version": "3.1.3",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
@@ -1587,12 +2160,24 @@
 					"integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
 					"requires": {
 						"ast-types": "0.9.6",
-						"esprima": "3.1.3",
-						"private": "0.1.8",
-						"source-map": "0.5.7"
+						"esprima": "~3.1.0",
+						"private": "~0.1.5",
+						"source-map": "~0.5.0"
 					}
 				}
 			}
+		},
+		"compare-versions": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.3.0.tgz",
+			"integrity": "sha512-MAAAIOdi2s4Gl6rZ76PNcUa9IOYB+5ICdT41o5uMRf09aEu/F9RK+qhe8RjXNPwcTjGV7KU7h2P/fljThFVqyQ==",
+			"dev": true
+		},
+		"component-emitter": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+			"integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+			"dev": true
 		},
 		"concat-map": {
 			"version": "0.0.1",
@@ -1600,13 +2185,14 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"concat-stream": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-			"integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+			"integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
 			"requires": {
-				"inherits": "2.0.3",
-				"readable-stream": "2.3.3",
-				"typedarray": "0.0.6"
+				"buffer-from": "^1.0.0",
+				"inherits": "^2.0.3",
+				"readable-stream": "^2.2.2",
+				"typedarray": "^0.0.6"
 			}
 		},
 		"content-type-parser": {
@@ -1618,6 +2204,12 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
 			"integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+		},
+		"copy-descriptor": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
+			"integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
+			"dev": true
 		},
 		"core-js": {
 			"version": "1.2.7",
@@ -1634,8 +2226,8 @@
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
 			"integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
 			"requires": {
-				"lru-cache": "4.1.1",
-				"which": "1.3.0"
+				"lru-cache": "^4.0.1",
+				"which": "^1.2.9"
 			}
 		},
 		"cryptiles": {
@@ -1643,7 +2235,7 @@
 			"resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
 			"integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
 			"requires": {
-				"boom": "5.2.0"
+				"boom": "5.x.x"
 			},
 			"dependencies": {
 				"boom": {
@@ -1651,7 +2243,7 @@
 					"resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
 					"integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
 					"requires": {
-						"hoek": "4.2.0"
+						"hoek": "4.x.x"
 					}
 				}
 			}
@@ -1666,7 +2258,7 @@
 			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
 			"integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
 			"requires": {
-				"cssom": "0.3.2"
+				"cssom": "0.3.x"
 			}
 		},
 		"d": {
@@ -1674,7 +2266,7 @@
 			"resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
 			"integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
 			"requires": {
-				"es5-ext": "0.10.35"
+				"es5-ext": "^0.10.9"
 			}
 		},
 		"dashdash": {
@@ -1682,7 +2274,46 @@
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
+			}
+		},
+		"data-urls": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.0.tgz",
+			"integrity": "sha512-ai40PPQR0Fn1lD2PPie79CibnlMN2AYiDhwFX/rZHVsxbs5kNJSjegqXIprhouGXlRdEnfybva7kqRGnB6mypA==",
+			"dev": true,
+			"requires": {
+				"abab": "^1.0.4",
+				"whatwg-mimetype": "^2.0.0",
+				"whatwg-url": "^6.4.0"
+			},
+			"dependencies": {
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"dev": true
+				},
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
+				"whatwg-url": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
+					}
+				}
 			}
 		},
 		"dateformat": {
@@ -1703,6 +2334,12 @@
 			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
 			"integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
 		},
+		"decode-uri-component": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"dev": true
+		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1713,7 +2350,70 @@
 			"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"requires": {
-				"strip-bom": "2.0.0"
+				"strip-bom": "^2.0.0"
+			}
+		},
+		"define-properties": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+			"dev": true,
+			"requires": {
+				"foreach": "^2.0.5",
+				"object-keys": "^1.0.8"
+			}
+		},
+		"define-property": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
+			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+			"dev": true,
+			"requires": {
+				"is-descriptor": "^1.0.2",
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
 			}
 		},
 		"defined": {
@@ -1726,16 +2426,23 @@
 			"resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
 			"integrity": "sha1-siYJ8sehG6ej2xFoBcE5scr/qdI=",
 			"requires": {
-				"alter": "0.2.0",
-				"ast-traverse": "0.1.1",
-				"breakable": "1.0.0",
-				"esprima-fb": "15001.1001.0-dev-harmony-fb",
-				"simple-fmt": "0.1.0",
-				"simple-is": "0.2.0",
-				"stringmap": "0.2.2",
-				"stringset": "0.2.1",
-				"tryor": "0.1.2",
-				"yargs": "3.27.0"
+				"alter": "~0.2.0",
+				"ast-traverse": "~0.1.1",
+				"breakable": "~1.0.0",
+				"esprima-fb": "~15001.1001.0-dev-harmony-fb",
+				"simple-fmt": "~0.1.0",
+				"simple-is": "~0.2.0",
+				"stringmap": "~0.2.2",
+				"stringset": "~0.2.1",
+				"tryor": "~0.1.2",
+				"yargs": "~3.27.0"
+			},
+			"dependencies": {
+				"esprima-fb": {
+					"version": "15001.1001.0-dev-harmony-fb",
+					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+					"integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+				}
 			}
 		},
 		"del": {
@@ -1743,13 +2450,13 @@
 			"resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
 			"integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
 			"requires": {
-				"globby": "5.0.0",
-				"is-path-cwd": "1.0.0",
-				"is-path-in-cwd": "1.0.0",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"rimraf": "2.2.8"
+				"globby": "^5.0.0",
+				"is-path-cwd": "^1.0.0",
+				"is-path-in-cwd": "^1.0.0",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"rimraf": "^2.2.8"
 			}
 		},
 		"delayed-stream": {
@@ -1762,18 +2469,31 @@
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
 			"integrity": "sha1-ncXl3bzu+DJXZLlFGwK8bVQIT3U=",
 			"requires": {
-				"get-stdin": "4.0.1",
-				"minimist": "1.2.0",
-				"repeating": "1.1.3"
+				"get-stdin": "^4.0.1",
+				"minimist": "^1.1.0",
+				"repeating": "^1.1.0"
 			}
 		},
+		"detect-newline": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+			"integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
+			"dev": true
+		},
 		"detective": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
-			"integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
+			"integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
 			"requires": {
-				"acorn": "4.0.13",
-				"defined": "1.0.0"
+				"acorn": "^5.2.1",
+				"defined": "^1.0.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+					"integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
+				}
 			}
 		},
 		"diff": {
@@ -1786,8 +2506,17 @@
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
 			"integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
 			"requires": {
-				"esutils": "2.0.2",
-				"isarray": "1.0.0"
+				"esutils": "^2.0.2",
+				"isarray": "^1.0.0"
+			}
+		},
+		"domexception": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+			"dev": true,
+			"requires": {
+				"webidl-conversions": "^4.0.2"
 			}
 		},
 		"duplexer2": {
@@ -1795,7 +2524,7 @@
 			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
 			"integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
 			"requires": {
-				"readable-stream": "1.1.14"
+				"readable-stream": "~1.1.9"
 			},
 			"dependencies": {
 				"isarray": {
@@ -1808,10 +2537,10 @@
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
 					"integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
 					"requires": {
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
 						"isarray": "0.0.1",
-						"string_decoder": "0.10.31"
+						"string_decoder": "~0.10.x"
 					}
 				},
 				"string_decoder": {
@@ -1827,7 +2556,7 @@
 			"integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
 			"optional": true,
 			"requires": {
-				"jsbn": "0.1.1"
+				"jsbn": "~0.1.0"
 			}
 		},
 		"errno": {
@@ -1835,7 +2564,7 @@
 			"resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
 			"integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
 			"requires": {
-				"prr": "0.0.0"
+				"prr": "~0.0.0"
 			}
 		},
 		"error-ex": {
@@ -1843,16 +2572,41 @@
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
+			}
+		},
+		"es-abstract": {
+			"version": "1.12.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
+			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+			"dev": true,
+			"requires": {
+				"es-to-primitive": "^1.1.1",
+				"function-bind": "^1.1.1",
+				"has": "^1.0.1",
+				"is-callable": "^1.1.3",
+				"is-regex": "^1.0.4"
+			}
+		},
+		"es-to-primitive": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+			"dev": true,
+			"requires": {
+				"is-callable": "^1.1.1",
+				"is-date-object": "^1.0.1",
+				"is-symbol": "^1.0.1"
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.35",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.35.tgz",
-			"integrity": "sha1-GO6FjOajxFx9eekcFfzKnsVoSU8=",
+			"version": "0.10.45",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
+			"integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
 			"requires": {
-				"es6-iterator": "2.0.3",
-				"es6-symbol": "3.1.1"
+				"es6-iterator": "~2.0.3",
+				"es6-symbol": "~3.1.1",
+				"next-tick": "1"
 			}
 		},
 		"es6-iterator": {
@@ -1860,9 +2614,9 @@
 			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
 			"integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"es6-map": {
@@ -1870,12 +2624,12 @@
 			"resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
 			"integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
-				"es6-set": "0.1.5",
-				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
+				"es6-set": "~0.1.5",
+				"es6-symbol": "~3.1.1",
+				"event-emitter": "~0.3.5"
 			}
 		},
 		"es6-set": {
@@ -1883,11 +2637,11 @@
 			"resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
 			"integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
+				"d": "1",
+				"es5-ext": "~0.10.14",
+				"es6-iterator": "~2.0.1",
 				"es6-symbol": "3.1.1",
-				"event-emitter": "0.3.5"
+				"event-emitter": "~0.3.5"
 			}
 		},
 		"es6-symbol": {
@@ -1895,8 +2649,8 @@
 			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
 			"integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"es6-weak-map": {
@@ -1904,10 +2658,10 @@
 			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
 			"integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35",
-				"es6-iterator": "2.0.3",
-				"es6-symbol": "3.1.1"
+				"d": "1",
+				"es5-ext": "^0.10.14",
+				"es6-iterator": "^2.0.1",
+				"es6-symbol": "^3.1.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -1920,11 +2674,11 @@
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
 			"integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
 			"requires": {
-				"esprima": "2.7.3",
-				"estraverse": "1.9.3",
-				"esutils": "2.0.2",
-				"optionator": "0.8.2",
-				"source-map": "0.2.0"
+				"esprima": "^2.7.1",
+				"estraverse": "^1.9.1",
+				"esutils": "^2.0.2",
+				"optionator": "^0.8.1",
+				"source-map": "~0.2.0"
 			},
 			"dependencies": {
 				"esprima": {
@@ -1943,7 +2697,7 @@
 					"integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
 					"optional": true,
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -1953,10 +2707,10 @@
 			"resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
 			"integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
 			"requires": {
-				"es6-map": "0.1.5",
-				"es6-weak-map": "2.0.2",
-				"esrecurse": "4.2.0",
-				"estraverse": "4.2.0"
+				"es6-map": "^0.1.3",
+				"es6-weak-map": "^2.0.1",
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
 			}
 		},
 		"eslint": {
@@ -1964,39 +2718,39 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-2.13.1.tgz",
 			"integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
 			"requires": {
-				"chalk": "1.1.3",
-				"concat-stream": "1.6.0",
-				"debug": "2.6.9",
-				"doctrine": "1.5.0",
-				"es6-map": "0.1.5",
-				"escope": "3.6.0",
-				"espree": "3.5.2",
-				"estraverse": "4.2.0",
-				"esutils": "2.0.2",
-				"file-entry-cache": "1.3.1",
-				"glob": "7.1.2",
-				"globals": "9.18.0",
-				"ignore": "3.3.7",
-				"imurmurhash": "0.1.4",
-				"inquirer": "0.12.0",
-				"is-my-json-valid": "2.16.1",
-				"is-resolvable": "1.0.0",
-				"js-yaml": "3.10.0",
-				"json-stable-stringify": "1.0.1",
-				"levn": "0.3.0",
-				"lodash": "4.17.4",
-				"mkdirp": "0.5.1",
-				"optionator": "0.8.2",
-				"path-is-absolute": "1.0.1",
-				"path-is-inside": "1.0.2",
-				"pluralize": "1.2.1",
-				"progress": "1.1.8",
-				"require-uncached": "1.0.3",
-				"shelljs": "0.6.1",
-				"strip-json-comments": "1.0.4",
-				"table": "3.8.3",
-				"text-table": "0.2.0",
-				"user-home": "2.0.0"
+				"chalk": "^1.1.3",
+				"concat-stream": "^1.4.6",
+				"debug": "^2.1.1",
+				"doctrine": "^1.2.2",
+				"es6-map": "^0.1.3",
+				"escope": "^3.6.0",
+				"espree": "^3.1.6",
+				"estraverse": "^4.2.0",
+				"esutils": "^2.0.2",
+				"file-entry-cache": "^1.1.1",
+				"glob": "^7.0.3",
+				"globals": "^9.2.0",
+				"ignore": "^3.1.2",
+				"imurmurhash": "^0.1.4",
+				"inquirer": "^0.12.0",
+				"is-my-json-valid": "^2.10.0",
+				"is-resolvable": "^1.0.0",
+				"js-yaml": "^3.5.1",
+				"json-stable-stringify": "^1.0.0",
+				"levn": "^0.3.0",
+				"lodash": "^4.0.0",
+				"mkdirp": "^0.5.0",
+				"optionator": "^0.8.1",
+				"path-is-absolute": "^1.0.0",
+				"path-is-inside": "^1.0.1",
+				"pluralize": "^1.2.1",
+				"progress": "^1.1.8",
+				"require-uncached": "^1.0.2",
+				"shelljs": "^0.6.0",
+				"strip-json-comments": "~1.0.1",
+				"table": "^3.7.8",
+				"text-table": "~0.2.0",
+				"user-home": "^2.0.0"
 			},
 			"dependencies": {
 				"glob": {
@@ -2004,12 +2758,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"globals": {
@@ -2022,7 +2776,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"user-home": {
@@ -2030,39 +2784,38 @@
 					"resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
 					"integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
 					"requires": {
-						"os-homedir": "1.0.2"
+						"os-homedir": "^1.0.0"
 					}
 				}
 			}
 		},
 		"espree": {
-			"version": "3.5.2",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.2.tgz",
-			"integrity": "sha512-sadKeYwaR/aJ3stC2CdvgXu1T16TdYN+qwCpcWbMnGJ8s0zNWemzrvb2GbD4OhmJ/fwpJjudThAlLobGbWZbCQ==",
+			"version": "3.5.4",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+			"integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
 			"requires": {
-				"acorn": "5.2.1",
-				"acorn-jsx": "3.0.1"
+				"acorn": "^5.5.0",
+				"acorn-jsx": "^3.0.0"
 			},
 			"dependencies": {
 				"acorn": {
-					"version": "5.2.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.2.1.tgz",
-					"integrity": "sha512-jG0u7c4Ly+3QkkW18V+NRDN+4bWHdln30NL1ZL2AvFZZmQe/BfopYCtghCKKVBUSetZ4QKcyA0pY6/4Gw8Pv8w=="
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+					"integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
 				}
 			}
 		},
-		"esprima-fb": {
-			"version": "15001.1001.0-dev-harmony-fb",
-			"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-			"integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+		"esprima": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+			"integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
 		},
 		"esrecurse": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-			"integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
 			"requires": {
-				"estraverse": "4.2.0",
-				"object-assign": "4.1.1"
+				"estraverse": "^4.1.0"
 			}
 		},
 		"estraverse": {
@@ -2080,8 +2833,8 @@
 			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
 			"integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
 			"requires": {
-				"d": "1.0.0",
-				"es5-ext": "0.10.35"
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"exec-sh": {
@@ -2089,7 +2842,7 @@
 			"resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
 			"integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
 			"requires": {
-				"merge": "1.2.0"
+				"merge": "^1.1.3"
 			}
 		},
 		"execa": {
@@ -2098,13 +2851,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "5.1.0",
-				"get-stream": "3.0.0",
-				"is-stream": "1.1.0",
-				"npm-run-path": "2.0.2",
-				"p-finally": "1.0.0",
-				"signal-exit": "3.0.2",
-				"strip-eof": "1.0.0"
+				"cross-spawn": "^5.0.1",
+				"get-stream": "^3.0.0",
+				"is-stream": "^1.1.0",
+				"npm-run-path": "^2.0.0",
+				"p-finally": "^1.0.0",
+				"signal-exit": "^3.0.0",
+				"strip-eof": "^1.0.0"
 			},
 			"dependencies": {
 				"cross-spawn": {
@@ -2113,12 +2866,18 @@
 					"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 					"dev": true,
 					"requires": {
-						"lru-cache": "4.1.1",
-						"shebang-command": "1.2.0",
-						"which": "1.3.0"
+						"lru-cache": "^4.0.1",
+						"shebang-command": "^1.2.0",
+						"which": "^1.2.9"
 					}
 				}
 			}
+		},
+		"exit": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+			"integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+			"dev": true
 		},
 		"exit-hook": {
 			"version": "1.1.1",
@@ -2130,7 +2889,7 @@
 			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"requires": {
-				"is-posix-bracket": "0.1.1"
+				"is-posix-bracket": "^0.1.0"
 			}
 		},
 		"expand-range": {
@@ -2138,21 +2897,21 @@
 			"resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"requires": {
-				"fill-range": "2.2.3"
+				"fill-range": "^2.1.0"
 			}
 		},
 		"expect": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
-			"integrity": "sha512-orfQQqFRTX0jH7znRIGi8ZMR8kTNpXklTTz8+HGTpmTKZo3Occ6JNB5FXMb8cRuiiC/GyDqsr30zUa66ACYlYw==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/expect/-/expect-23.2.0.tgz",
+			"integrity": "sha1-U6fhNeNv4n51hnsReP8IqqzCsN0=",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "3.2.0",
-				"jest-diff": "21.2.1",
-				"jest-get-type": "21.2.0",
-				"jest-matcher-utils": "21.2.1",
-				"jest-message-util": "21.2.1",
-				"jest-regex-util": "21.2.0"
+				"ansi-styles": "^3.2.0",
+				"jest-diff": "^23.2.0",
+				"jest-get-type": "^22.1.0",
+				"jest-matcher-utils": "^23.2.0",
+				"jest-message-util": "^23.2.0",
+				"jest-regex-util": "^23.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -2162,71 +2921,71 @@
 					"dev": true
 				},
 				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
 				"jest-diff": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
-					"integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
+					"integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"diff": "3.4.0",
-						"jest-get-type": "21.2.0",
-						"pretty-format": "21.2.1"
+						"chalk": "^2.0.1",
+						"diff": "^3.2.0",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-matcher-utils": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
-					"integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
+					"integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"jest-get-type": "21.2.0",
-						"pretty-format": "21.2.1"
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"pretty-format": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-					"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0",
-						"ansi-styles": "3.2.0"
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
 					}
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -2236,12 +2995,33 @@
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
 			"integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
 		},
+		"extend-shallow": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+			"dev": true,
+			"requires": {
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
+		},
 		"extglob": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"extsprintf": {
@@ -2250,12 +3030,13 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
 		},
 		"fancy-log": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-			"integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+			"integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
 			"requires": {
-				"chalk": "1.1.3",
-				"time-stamp": "1.1.0"
+				"ansi-gray": "^0.1.1",
+				"color-support": "^1.1.3",
+				"time-stamp": "^1.0.0"
 			}
 		},
 		"fast-deep-equal": {
@@ -2286,41 +3067,46 @@
 			"resolved": "https://registry.npmjs.org/fbjs-scripts/-/fbjs-scripts-0.7.1.tgz",
 			"integrity": "sha1-TxFeIY4kPjrdvw7dqsHjxi9wP6w=",
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-preset-fbjs": "1.0.0",
-				"core-js": "1.2.7",
-				"cross-spawn": "3.0.1",
-				"gulp-util": "3.0.8",
-				"object-assign": "4.1.1",
-				"semver": "5.4.1",
-				"through2": "2.0.3"
+				"babel-core": "^6.7.2",
+				"babel-preset-fbjs": "^1.0.0",
+				"core-js": "^1.0.0",
+				"cross-spawn": "^3.0.1",
+				"gulp-util": "^3.0.4",
+				"object-assign": "^4.0.1",
+				"semver": "^5.1.0",
+				"through2": "^2.0.0"
 			},
 			"dependencies": {
 				"babel-core": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-					"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-generator": "6.26.0",
-						"babel-helpers": "6.24.1",
-						"babel-messages": "6.23.0",
-						"babel-register": "6.26.0",
-						"babel-runtime": "6.26.0",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"convert-source-map": "1.5.0",
-						"debug": "2.6.9",
-						"json5": "0.5.1",
-						"lodash": "4.17.4",
-						"minimatch": "3.0.4",
-						"path-is-absolute": "1.0.1",
-						"private": "0.1.8",
-						"slash": "1.0.0",
-						"source-map": "0.5.7"
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
 					}
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 				},
 				"json5": {
 					"version": "0.5.1",
@@ -2332,7 +3118,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				}
 			}
@@ -2342,8 +3128,8 @@
 			"resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 			"requires": {
-				"escape-string-regexp": "1.0.5",
-				"object-assign": "4.1.1"
+				"escape-string-regexp": "^1.0.5",
+				"object-assign": "^4.1.0"
 			}
 		},
 		"file-entry-cache": {
@@ -2351,8 +3137,8 @@
 			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-1.3.1.tgz",
 			"integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
 			"requires": {
-				"flat-cache": "1.3.0",
-				"object-assign": "4.1.1"
+				"flat-cache": "^1.2.1",
+				"object-assign": "^4.0.1"
 			}
 		},
 		"filename-regex": {
@@ -2365,8 +3151,8 @@
 			"resolved": "https://registry.npmjs.org/fileset/-/fileset-2.0.3.tgz",
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"requires": {
-				"glob": "7.1.2",
-				"minimatch": "3.0.4"
+				"glob": "^7.0.3",
+				"minimatch": "^3.0.3"
 			},
 			"dependencies": {
 				"glob": {
@@ -2374,12 +3160,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"minimatch": {
@@ -2387,7 +3173,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				}
 			}
@@ -2397,11 +3183,11 @@
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
 			"integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
 			"requires": {
-				"is-number": "2.1.0",
-				"isobject": "2.1.0",
-				"randomatic": "1.1.7",
-				"repeat-element": "1.1.2",
-				"repeat-string": "1.6.1"
+				"is-number": "^2.1.0",
+				"isobject": "^2.0.0",
+				"randomatic": "^1.1.3",
+				"repeat-element": "^1.1.2",
+				"repeat-string": "^1.5.2"
 			}
 		},
 		"find-up": {
@@ -2409,8 +3195,8 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 			"requires": {
-				"path-exists": "2.1.0",
-				"pinkie-promise": "2.0.1"
+				"path-exists": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			},
 			"dependencies": {
 				"path-exists": {
@@ -2418,7 +3204,7 @@
 					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"requires": {
-						"pinkie-promise": "2.0.1"
+						"pinkie-promise": "^2.0.0"
 					}
 				}
 			}
@@ -2428,16 +3214,16 @@
 			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
 			"integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
 			"requires": {
-				"circular-json": "0.3.3",
-				"del": "2.2.2",
-				"graceful-fs": "4.1.11",
-				"write": "0.2.1"
+				"circular-json": "^0.3.1",
+				"del": "^2.0.2",
+				"graceful-fs": "^4.1.2",
+				"write": "^0.2.1"
 			}
 		},
 		"flow-parser": {
-			"version": "0.59.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.59.0.tgz",
-			"integrity": "sha1-9uvK5h/6GH5CCZnUDOCoAfObJjU="
+			"version": "0.75.0",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.75.0.tgz",
+			"integrity": "sha512-QEyV/t9TERBOSI/zSx0zhKH6924135WPI7pMmug2n/n/4puFm4mdAq1QaKPA3IPhXDRtManbySkKhRqws5UUGA=="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -2449,8 +3235,14 @@
 			"resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"requires": {
-				"for-in": "1.0.2"
+				"for-in": "^1.0.1"
 			}
+		},
+		"foreach": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+			"integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+			"dev": true
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -2462,9 +3254,18 @@
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
 			"integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
 			"requires": {
-				"asynckit": "0.4.0",
-				"combined-stream": "1.0.5",
-				"mime-types": "2.1.17"
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.5",
+				"mime-types": "^2.1.12"
+			}
+		},
+		"fragment-cache": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
+			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
+			"dev": true,
+			"requires": {
+				"map-cache": "^0.2.2"
 			}
 		},
 		"fs-readdir-recursive": {
@@ -2478,31 +3279,21 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-			"integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "2.8.0",
-				"node-pre-gyp": "0.6.39"
+				"nan": "^2.9.2",
+				"node-pre-gyp": "^0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
-					"version": "1.1.0",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
-				},
-				"ajv": {
-					"version": "4.11.8",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"co": "4.6.0",
-						"json-stable-stringify": "1.0.1"
-					}
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
@@ -2510,7 +3301,7 @@
 					"dev": true
 				},
 				"aproba": {
-					"version": "1.1.1",
+					"version": "1.2.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2521,92 +3312,26 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "1.0.0",
-						"readable-stream": "2.2.9"
+						"delegates": "^1.0.0",
+						"readable-stream": "^2.0.6"
 					}
-				},
-				"asn1": {
-					"version": "0.2.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"assert-plus": {
-					"version": "0.2.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"asynckit": {
-					"version": "0.4.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"aws-sign2": {
-					"version": "0.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"aws4": {
-					"version": "1.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"balanced-match": {
-					"version": "0.4.2",
-					"bundled": true,
-					"dev": true
-				},
-				"bcrypt-pbkdf": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"tweetnacl": "0.14.5"
-					}
-				},
-				"block-stream": {
-					"version": "0.0.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"inherits": "2.0.3"
-					}
-				},
-				"boom": {
-					"version": "2.10.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"brace-expansion": {
-					"version": "1.1.7",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"balanced-match": "0.4.2",
-						"concat-map": "0.0.1"
-					}
-				},
-				"buffer-shims": {
 					"version": "1.0.0",
 					"bundled": true,
 					"dev": true
 				},
-				"caseless": {
-					"version": "0.12.0",
+				"brace-expansion": {
+					"version": "1.1.11",
 					"bundled": true,
 					"dev": true,
-					"optional": true
+					"requires": {
+						"balanced-match": "^1.0.0",
+						"concat-map": "0.0.1"
+					}
 				},
-				"co": {
-					"version": "4.6.0",
+				"chownr": {
+					"version": "1.0.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2615,14 +3340,6 @@
 					"version": "1.1.0",
 					"bundled": true,
 					"dev": true
-				},
-				"combined-stream": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"delayed-stream": "1.0.0"
-					}
 				},
 				"concat-map": {
 					"version": "0.0.1",
@@ -2637,35 +3354,11 @@
 				"core-util-is": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
-				},
-				"cryptiles": {
-					"version": "2.0.5",
-					"bundled": true,
 					"dev": true,
-					"requires": {
-						"boom": "2.10.1"
-					}
-				},
-				"dashdash": {
-					"version": "1.14.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
+					"optional": true
 				},
 				"debug": {
-					"version": "2.6.8",
+					"version": "2.6.9",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
@@ -2674,15 +3367,10 @@
 					}
 				},
 				"deep-extend": {
-					"version": "0.4.2",
+					"version": "0.5.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true
-				},
-				"delayed-stream": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
 				},
 				"delegates": {
 					"version": "1.0.0",
@@ -2691,74 +3379,25 @@
 					"optional": true
 				},
 				"detect-libc": {
-					"version": "1.0.2",
+					"version": "1.0.3",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
-				"ecc-jsbn": {
-					"version": "0.1.1",
+				"fs-minipass": {
+					"version": "1.2.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"extend": {
-					"version": "3.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"extsprintf": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"forever-agent": {
-					"version": "0.6.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"form-data": {
-					"version": "2.1.4",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"asynckit": "0.4.0",
-						"combined-stream": "1.0.5",
-						"mime-types": "2.1.15"
+						"minipass": "^2.2.1"
 					}
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
-				},
-				"fstream": {
-					"version": "1.0.11",
-					"bundled": true,
 					"dev": true,
-					"requires": {
-						"graceful-fs": "4.1.11",
-						"inherits": "2.0.3",
-						"mkdirp": "0.5.1",
-						"rimraf": "2.6.1"
-					}
-				},
-				"fstream-ignore": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"fstream": "1.0.11",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4"
-					}
+					"optional": true
 				},
 				"gauge": {
 					"version": "2.7.4",
@@ -2766,65 +3405,28 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "1.1.1",
-						"console-control-strings": "1.1.0",
-						"has-unicode": "2.0.1",
-						"object-assign": "4.1.1",
-						"signal-exit": "3.0.2",
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wide-align": "1.1.2"
-					}
-				},
-				"getpass": {
-					"version": "0.1.7",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
+						"aproba": "^1.0.3",
+						"console-control-strings": "^1.0.0",
+						"has-unicode": "^2.0.0",
+						"object-assign": "^4.1.0",
+						"signal-exit": "^3.0.0",
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wide-align": "^1.1.0"
 					}
 				},
 				"glob": {
 					"version": "7.1.2",
 					"bundled": true,
 					"dev": true,
-					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
-					}
-				},
-				"graceful-fs": {
-					"version": "4.1.11",
-					"bundled": true,
-					"dev": true
-				},
-				"har-schema": {
-					"version": "1.0.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"har-validator": {
-					"version": "4.2.1",
-					"bundled": true,
-					"dev": true,
 					"optional": true,
 					"requires": {
-						"ajv": "4.11.8",
-						"har-schema": "1.0.5"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-unicode": {
@@ -2833,40 +3435,32 @@
 					"dev": true,
 					"optional": true
 				},
-				"hawk": {
-					"version": "3.1.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"boom": "2.10.1",
-						"cryptiles": "2.0.5",
-						"hoek": "2.16.3",
-						"sntp": "1.0.9"
-					}
-				},
-				"hoek": {
-					"version": "2.16.3",
-					"bundled": true,
-					"dev": true
-				},
-				"http-signature": {
-					"version": "1.1.1",
+				"iconv-lite": {
+					"version": "0.4.21",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"assert-plus": "0.2.0",
-						"jsprim": "1.4.0",
-						"sshpk": "1.13.0"
+						"safer-buffer": "^2.1.0"
+					}
+				},
+				"ignore-walk": {
+					"version": "3.0.1",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minimatch": "^3.0.4"
 					}
 				},
 				"inflight": {
 					"version": "1.0.6",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"once": "1.4.0",
-						"wrappy": "1.0.2"
+						"once": "^1.3.0",
+						"wrappy": "1"
 					}
 				},
 				"inherits": {
@@ -2875,7 +3469,7 @@
 					"dev": true
 				},
 				"ini": {
-					"version": "1.3.4",
+					"version": "1.3.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -2885,113 +3479,45 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "1.0.1"
+						"number-is-nan": "^1.0.0"
 					}
-				},
-				"is-typedarray": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"isarray": {
 					"version": "1.0.0",
 					"bundled": true,
-					"dev": true
-				},
-				"isstream": {
-					"version": "0.1.2",
-					"bundled": true,
 					"dev": true,
 					"optional": true
-				},
-				"jodid25519": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"jsbn": "0.1.1"
-					}
-				},
-				"jsbn": {
-					"version": "0.1.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"json-schema": {
-					"version": "0.2.3",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"json-stable-stringify": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"jsonify": "0.0.0"
-					}
-				},
-				"json-stringify-safe": {
-					"version": "5.0.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"jsonify": {
-					"version": "0.0.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"jsprim": {
-					"version": "1.4.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"assert-plus": "1.0.0",
-						"extsprintf": "1.0.2",
-						"json-schema": "0.2.3",
-						"verror": "1.3.6"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
-				"mime-db": {
-					"version": "1.27.0",
-					"bundled": true,
-					"dev": true
-				},
-				"mime-types": {
-					"version": "2.1.15",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"mime-db": "1.27.0"
-					}
 				},
 				"minimatch": {
 					"version": "3.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.7"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"minimist": {
 					"version": "0.0.8",
 					"bundled": true,
 					"dev": true
+				},
+				"minipass": {
+					"version": "2.2.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "1.1.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"minipass": "^2.2.1"
+					}
 				},
 				"mkdirp": {
 					"version": "0.5.1",
@@ -3007,23 +3533,33 @@
 					"dev": true,
 					"optional": true
 				},
-				"node-pre-gyp": {
-					"version": "0.6.39",
+				"needle": {
+					"version": "2.2.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "1.0.2",
-						"hawk": "3.1.3",
-						"mkdirp": "0.5.1",
-						"nopt": "4.0.1",
-						"npmlog": "4.1.0",
-						"rc": "1.2.1",
-						"request": "2.81.0",
-						"rimraf": "2.6.1",
-						"semver": "5.3.0",
-						"tar": "2.2.1",
-						"tar-pack": "3.4.0"
+						"debug": "^2.1.2",
+						"iconv-lite": "^0.4.4",
+						"sax": "^1.2.4"
+					}
+				},
+				"node-pre-gyp": {
+					"version": "0.10.0",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"detect-libc": "^1.0.2",
+						"mkdirp": "^0.5.1",
+						"needle": "^2.2.0",
+						"nopt": "^4.0.1",
+						"npm-packlist": "^1.1.6",
+						"npmlog": "^4.0.2",
+						"rc": "^1.1.7",
+						"rimraf": "^2.6.1",
+						"semver": "^5.3.0",
+						"tar": "^4"
 					}
 				},
 				"nopt": {
@@ -3032,32 +3568,42 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1.1.0",
-						"osenv": "0.1.4"
+						"abbrev": "1",
+						"osenv": "^0.1.4"
 					}
 				},
-				"npmlog": {
-					"version": "4.1.0",
+				"npm-bundled": {
+					"version": "1.0.3",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"npm-packlist": {
+					"version": "1.1.10",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "1.1.4",
-						"console-control-strings": "1.1.0",
-						"gauge": "2.7.4",
-						"set-blocking": "2.0.0"
+						"ignore-walk": "^3.0.1",
+						"npm-bundled": "^1.0.1"
+					}
+				},
+				"npmlog": {
+					"version": "4.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"are-we-there-yet": "~1.1.2",
+						"console-control-strings": "~1.1.0",
+						"gauge": "~2.7.3",
+						"set-blocking": "~2.0.0"
 					}
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
 					"bundled": true,
 					"dev": true
-				},
-				"oauth-sign": {
-					"version": "0.8.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3070,7 +3616,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1.0.2"
+						"wrappy": "1"
 					}
 				},
 				"os-homedir": {
@@ -3086,53 +3632,37 @@
 					"optional": true
 				},
 				"osenv": {
-					"version": "0.1.4",
+					"version": "0.1.5",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "1.0.2",
-						"os-tmpdir": "1.0.2"
+						"os-homedir": "^1.0.0",
+						"os-tmpdir": "^1.0.0"
 					}
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
 					"bundled": true,
-					"dev": true
-				},
-				"performance-now": {
-					"version": "0.2.0",
-					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"process-nextick-args": {
-					"version": "1.0.7",
-					"bundled": true,
-					"dev": true
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"qs": {
-					"version": "6.4.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
 				},
 				"rc": {
-					"version": "1.2.1",
+					"version": "1.2.7",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "0.4.2",
-						"ini": "1.3.4",
-						"minimist": "1.2.0",
-						"strip-json-comments": "2.0.1"
+						"deep-extend": "^0.5.1",
+						"ini": "~1.3.0",
+						"minimist": "^1.2.0",
+						"strip-json-comments": "~2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -3144,64 +3674,48 @@
 					}
 				},
 				"readable-stream": {
-					"version": "2.2.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"buffer-shims": "1.0.0",
-						"core-util-is": "1.0.2",
-						"inherits": "2.0.3",
-						"isarray": "1.0.0",
-						"process-nextick-args": "1.0.7",
-						"string_decoder": "1.0.1",
-						"util-deprecate": "1.0.2"
-					}
-				},
-				"request": {
-					"version": "2.81.0",
+					"version": "2.3.6",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aws-sign2": "0.6.0",
-						"aws4": "1.6.0",
-						"caseless": "0.12.0",
-						"combined-stream": "1.0.5",
-						"extend": "3.0.1",
-						"forever-agent": "0.6.1",
-						"form-data": "2.1.4",
-						"har-validator": "4.2.1",
-						"hawk": "3.1.3",
-						"http-signature": "1.1.1",
-						"is-typedarray": "1.0.0",
-						"isstream": "0.1.2",
-						"json-stringify-safe": "5.0.1",
-						"mime-types": "2.1.15",
-						"oauth-sign": "0.8.2",
-						"performance-now": "0.2.0",
-						"qs": "6.4.0",
-						"safe-buffer": "5.0.1",
-						"stringstream": "0.0.5",
-						"tough-cookie": "2.3.2",
-						"tunnel-agent": "0.6.0",
-						"uuid": "3.0.1"
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.3",
+						"isarray": "~1.0.0",
+						"process-nextick-args": "~2.0.0",
+						"safe-buffer": "~5.1.1",
+						"string_decoder": "~1.1.1",
+						"util-deprecate": "~1.0.1"
 					}
 				},
 				"rimraf": {
-					"version": "2.6.1",
+					"version": "2.6.2",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				},
 				"safe-buffer": {
-					"version": "5.0.1",
+					"version": "5.1.1",
 					"bundled": true,
 					"dev": true
 				},
+				"safer-buffer": {
+					"version": "2.1.2",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
+				"sax": {
+					"version": "1.2.4",
+					"bundled": true,
+					"dev": true,
+					"optional": true
+				},
 				"semver": {
-					"version": "5.3.0",
+					"version": "5.5.0",
 					"bundled": true,
 					"dev": true,
 					"optional": true
@@ -3218,69 +3732,31 @@
 					"dev": true,
 					"optional": true
 				},
-				"sntp": {
-					"version": "1.0.9",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"hoek": "2.16.3"
-					}
-				},
-				"sshpk": {
-					"version": "1.13.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"asn1": "0.2.3",
-						"assert-plus": "1.0.0",
-						"bcrypt-pbkdf": "1.0.1",
-						"dashdash": "1.14.1",
-						"ecc-jsbn": "0.1.1",
-						"getpass": "0.1.7",
-						"jodid25519": "1.0.2",
-						"jsbn": "0.1.1",
-						"tweetnacl": "0.14.5"
-					},
-					"dependencies": {
-						"assert-plus": {
-							"version": "1.0.0",
-							"bundled": true,
-							"dev": true,
-							"optional": true
-						}
-					}
-				},
 				"string-width": {
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"code-point-at": "1.1.0",
-						"is-fullwidth-code-point": "1.0.0",
-						"strip-ansi": "3.0.1"
+						"code-point-at": "^1.0.0",
+						"is-fullwidth-code-point": "^1.0.0",
+						"strip-ansi": "^3.0.0"
 					}
 				},
 				"string_decoder": {
-					"version": "1.0.1",
+					"version": "1.1.1",
 					"bundled": true,
 					"dev": true,
+					"optional": true,
 					"requires": {
-						"safe-buffer": "5.0.1"
+						"safe-buffer": "~5.1.0"
 					}
-				},
-				"stringstream": {
-					"version": "0.0.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "2.1.1"
+						"ansi-regex": "^2.0.0"
 					}
 				},
 				"strip-json-comments": {
@@ -3290,80 +3766,25 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "2.2.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"block-stream": "0.0.9",
-						"fstream": "1.0.11",
-						"inherits": "2.0.3"
-					}
-				},
-				"tar-pack": {
-					"version": "3.4.0",
+					"version": "4.4.1",
 					"bundled": true,
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "2.6.8",
-						"fstream": "1.0.11",
-						"fstream-ignore": "1.0.5",
-						"once": "1.4.0",
-						"readable-stream": "2.2.9",
-						"rimraf": "2.6.1",
-						"tar": "2.2.1",
-						"uid-number": "0.0.6"
+						"chownr": "^1.0.1",
+						"fs-minipass": "^1.2.5",
+						"minipass": "^2.2.4",
+						"minizlib": "^1.1.0",
+						"mkdirp": "^0.5.0",
+						"safe-buffer": "^5.1.1",
+						"yallist": "^3.0.2"
 					}
-				},
-				"tough-cookie": {
-					"version": "2.3.2",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"punycode": "1.4.1"
-					}
-				},
-				"tunnel-agent": {
-					"version": "0.6.0",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"safe-buffer": "5.0.1"
-					}
-				},
-				"tweetnacl": {
-					"version": "0.14.5",
-					"bundled": true,
-					"dev": true,
-					"optional": true
-				},
-				"uid-number": {
-					"version": "0.0.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
 					"bundled": true,
-					"dev": true
-				},
-				"uuid": {
-					"version": "3.0.1",
-					"bundled": true,
 					"dev": true,
 					"optional": true
-				},
-				"verror": {
-					"version": "1.3.6",
-					"bundled": true,
-					"dev": true,
-					"optional": true,
-					"requires": {
-						"extsprintf": "1.0.2"
-					}
 				},
 				"wide-align": {
 					"version": "1.1.2",
@@ -3371,15 +3792,26 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "1.0.2"
+						"string-width": "^1.0.2"
 					}
 				},
 				"wrappy": {
 					"version": "1.0.2",
 					"bundled": true,
 					"dev": true
+				},
+				"yallist": {
+					"version": "3.0.2",
+					"bundled": true,
+					"dev": true
 				}
 			}
+		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true
 		},
 		"generate-function": {
 			"version": "2.0.0",
@@ -3391,7 +3823,7 @@
 			"resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
 			"integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
 			"requires": {
-				"is-property": "1.0.2"
+				"is-property": "^1.0.0"
 			}
 		},
 		"get-caller-file": {
@@ -3410,12 +3842,18 @@
 			"integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
 			"dev": true
 		},
+		"get-value": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
+			"integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
+			"dev": true
+		},
 		"getpass": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"requires": {
-				"assert-plus": "1.0.0"
+				"assert-plus": "^1.0.0"
 			}
 		},
 		"glob": {
@@ -3423,11 +3861,11 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 			"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 			"requires": {
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "2.0.10",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "2 || 3",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"glob-base": {
@@ -3435,8 +3873,8 @@
 			"resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"requires": {
-				"glob-parent": "2.0.0",
-				"is-glob": "2.0.1"
+				"glob-parent": "^2.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"glob-parent": {
@@ -3444,7 +3882,7 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"requires": {
-				"is-glob": "2.0.1"
+				"is-glob": "^2.0.0"
 			}
 		},
 		"globals": {
@@ -3457,12 +3895,12 @@
 			"resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
 			"integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
 			"requires": {
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"glob": "7.1.2",
-				"object-assign": "4.1.1",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"glob": "^7.0.3",
+				"object-assign": "^4.0.1",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			},
 			"dependencies": {
 				"glob": {
@@ -3470,12 +3908,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"minimatch": {
@@ -3483,17 +3921,17 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				}
 			}
 		},
 		"glogg": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
-			"integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
+			"integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
 			"requires": {
-				"sparkles": "1.0.0"
+				"sparkles": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -3511,24 +3949,24 @@
 			"resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
 			"integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-uniq": "1.0.3",
-				"beeper": "1.1.1",
-				"chalk": "1.1.3",
-				"dateformat": "2.2.0",
-				"fancy-log": "1.3.0",
-				"gulplog": "1.0.0",
-				"has-gulplog": "0.1.0",
-				"lodash._reescape": "3.0.0",
-				"lodash._reevaluate": "3.0.0",
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.template": "3.6.2",
-				"minimist": "1.2.0",
-				"multipipe": "0.1.2",
-				"object-assign": "3.0.0",
+				"array-differ": "^1.0.0",
+				"array-uniq": "^1.0.2",
+				"beeper": "^1.0.0",
+				"chalk": "^1.0.0",
+				"dateformat": "^2.0.0",
+				"fancy-log": "^1.1.0",
+				"gulplog": "^1.0.0",
+				"has-gulplog": "^0.1.0",
+				"lodash._reescape": "^3.0.0",
+				"lodash._reevaluate": "^3.0.0",
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.template": "^3.0.0",
+				"minimist": "^1.1.0",
+				"multipipe": "^0.1.2",
+				"object-assign": "^3.0.0",
 				"replace-ext": "0.0.1",
-				"through2": "2.0.3",
-				"vinyl": "0.5.3"
+				"through2": "^2.0.0",
+				"vinyl": "^0.5.0"
 			},
 			"dependencies": {
 				"object-assign": {
@@ -3543,7 +3981,7 @@
 			"resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
 			"integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
 			"requires": {
-				"glogg": "1.0.0"
+				"glogg": "^1.0.0"
 			}
 		},
 		"handlebars": {
@@ -3551,10 +3989,10 @@
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
 			"integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
 			"requires": {
-				"async": "1.5.2",
-				"optimist": "0.6.1",
-				"source-map": "0.4.4",
-				"uglify-js": "2.8.29"
+				"async": "^1.4.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.4.4",
+				"uglify-js": "^2.6"
 			},
 			"dependencies": {
 				"source-map": {
@@ -3562,7 +4000,7 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
 					"integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
@@ -3577,8 +4015,8 @@
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"requires": {
-				"ajv": "5.4.0",
-				"har-schema": "2.0.0"
+				"ajv": "^5.1.0",
+				"har-schema": "^2.0.0"
 			},
 			"dependencies": {
 				"ajv": {
@@ -3586,12 +4024,21 @@
 					"resolved": "https://registry.npmjs.org/ajv/-/ajv-5.4.0.tgz",
 					"integrity": "sha1-MtHPCNvIDEMvQm8S4QslEfa0ZHQ=",
 					"requires": {
-						"co": "4.6.0",
-						"fast-deep-equal": "1.0.0",
-						"fast-json-stable-stringify": "2.0.0",
-						"json-schema-traverse": "0.3.1"
+						"co": "^4.6.0",
+						"fast-deep-equal": "^1.0.0",
+						"fast-json-stable-stringify": "^2.0.0",
+						"json-schema-traverse": "^0.3.0"
 					}
 				}
+			}
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
+			"requires": {
+				"function-bind": "^1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -3599,7 +4046,7 @@
 			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"has-color": {
@@ -3617,7 +4064,67 @@
 			"resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
 			"integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
 			"requires": {
-				"sparkles": "1.0.0"
+				"sparkles": "^1.0.0"
+			}
+		},
+		"has-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
+			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
+			"dev": true,
+			"requires": {
+				"get-value": "^2.0.6",
+				"has-values": "^1.0.0",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
+		},
+		"has-values": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
+			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"kind-of": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+					"dev": true,
+					"requires": {
+						"is-buffer": "^1.1.5"
+					}
+				}
 			}
 		},
 		"hawk": {
@@ -3625,10 +4132,10 @@
 			"resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
 			"integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
 			"requires": {
-				"boom": "4.3.1",
-				"cryptiles": "3.1.2",
-				"hoek": "4.2.0",
-				"sntp": "2.1.0"
+				"boom": "4.x.x",
+				"cryptiles": "3.x.x",
+				"hoek": "4.x.x",
+				"sntp": "2.x.x"
 			}
 		},
 		"hoek": {
@@ -3641,8 +4148,8 @@
 			"resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
 			"integrity": "sha1-S58eQIAMPlDGwn94FnavzOcfOYU=",
 			"requires": {
-				"os-tmpdir": "1.0.2",
-				"user-home": "1.1.1"
+				"os-tmpdir": "^1.0.1",
+				"user-home": "^1.1.1"
 			}
 		},
 		"hosted-git-info": {
@@ -3655,7 +4162,7 @@
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"requires": {
-				"whatwg-encoding": "1.0.3"
+				"whatwg-encoding": "^1.0.1"
 			}
 		},
 		"http-signature": {
@@ -3663,9 +4170,9 @@
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"requires": {
-				"assert-plus": "1.0.0",
-				"jsprim": "1.4.1",
-				"sshpk": "1.13.1"
+				"assert-plus": "^1.0.0",
+				"jsprim": "^1.2.2",
+				"sshpk": "^1.7.0"
 			}
 		},
 		"iconv-lite": {
@@ -3674,9 +4181,19 @@
 			"integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
 		},
 		"ignore": {
-			"version": "3.3.7",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
-			"integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+			"version": "3.3.10",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+			"integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug=="
+		},
+		"import-local": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/import-local/-/import-local-1.0.0.tgz",
+			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
+			"dev": true,
+			"requires": {
+				"pkg-dir": "^2.0.0",
+				"resolve-cwd": "^2.0.0"
+			}
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
@@ -3688,8 +4205,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -3702,19 +4219,19 @@
 			"resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
 			"integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
 			"requires": {
-				"ansi-escapes": "1.4.0",
-				"ansi-regex": "2.1.1",
-				"chalk": "1.1.3",
-				"cli-cursor": "1.0.2",
-				"cli-width": "2.2.0",
-				"figures": "1.7.0",
-				"lodash": "4.17.4",
-				"readline2": "1.0.1",
-				"run-async": "0.1.0",
-				"rx-lite": "3.1.2",
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1",
-				"through": "2.3.8"
+				"ansi-escapes": "^1.1.0",
+				"ansi-regex": "^2.0.0",
+				"chalk": "^1.0.0",
+				"cli-cursor": "^1.0.1",
+				"cli-width": "^2.0.0",
+				"figures": "^1.3.5",
+				"lodash": "^4.3.0",
+				"readline2": "^1.0.1",
+				"run-async": "^0.1.0",
+				"rx-lite": "^3.1.2",
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.0",
+				"through": "^2.3.6"
 			}
 		},
 		"invariant": {
@@ -3722,13 +4239,22 @@
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
 			"integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
 			"requires": {
-				"loose-envify": "1.3.1"
+				"loose-envify": "^1.0.0"
 			}
 		},
 		"invert-kv": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
 			"integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+		},
+		"is-accessor-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -3745,15 +4271,55 @@
 			"resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
+		},
+		"is-callable": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+			"integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+			"dev": true
 		},
 		"is-ci": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
 			"integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
 			"requires": {
-				"ci-info": "1.1.2"
+				"ci-info": "^1.0.0"
+			}
+		},
+		"is-data-descriptor": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
+		},
+		"is-date-object": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+			"dev": true
+		},
+		"is-descriptor": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+			"dev": true,
+			"requires": {
+				"is-accessor-descriptor": "^0.1.6",
+				"is-data-descriptor": "^0.1.4",
+				"kind-of": "^5.0.0"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+					"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+					"dev": true
+				}
 			}
 		},
 		"is-dotfile": {
@@ -3766,7 +4332,7 @@
 			"resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"requires": {
-				"is-primitive": "2.0.0"
+				"is-primitive": "^2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -3784,7 +4350,7 @@
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -3792,15 +4358,21 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
+		},
+		"is-generator-fn": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-1.0.0.tgz",
+			"integrity": "sha1-lp1J4bszKfa7fwkIm+JleLLd1Go=",
+			"dev": true
 		},
 		"is-glob": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"requires": {
-				"is-extglob": "1.0.0"
+				"is-extglob": "^1.0.0"
 			}
 		},
 		"is-integer": {
@@ -3808,18 +4380,24 @@
 			"resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.7.tgz",
 			"integrity": "sha1-a96Bqs3feLZZtmKdYpytxRqIbVw=",
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
+		"is-my-ip-valid": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
+			"integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ=="
+		},
 		"is-my-json-valid": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-			"integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+			"version": "2.17.2",
+			"resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
+			"integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
 			"requires": {
-				"generate-function": "2.0.0",
-				"generate-object-property": "1.2.0",
-				"jsonpointer": "4.0.1",
-				"xtend": "4.0.1"
+				"generate-function": "^2.0.0",
+				"generate-object-property": "^1.1.0",
+				"is-my-ip-valid": "^1.0.0",
+				"jsonpointer": "^4.0.0",
+				"xtend": "^4.0.0"
 			}
 		},
 		"is-number": {
@@ -3827,7 +4405,7 @@
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"requires": {
-				"kind-of": "3.2.2"
+				"kind-of": "^3.0.2"
 			}
 		},
 		"is-path-cwd": {
@@ -3836,19 +4414,36 @@
 			"integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0="
 		},
 		"is-path-in-cwd": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-			"integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+			"integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
 			"requires": {
-				"is-path-inside": "1.0.0"
+				"is-path-inside": "^1.0.0"
 			}
 		},
 		"is-path-inside": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-			"integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+			"integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
 			"requires": {
-				"path-is-inside": "1.0.2"
+				"path-is-inside": "^1.0.1"
+			}
+		},
+		"is-plain-object": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"is-posix-bracket": {
@@ -3866,18 +4461,30 @@
 			"resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
 			"integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
 		},
-		"is-resolvable": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-			"integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+		"is-regex": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"dev": true,
 			"requires": {
-				"tryit": "1.0.3"
+				"has": "^1.0.1"
 			}
+		},
+		"is-resolvable": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+			"integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg=="
 		},
 		"is-stream": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+			"dev": true
+		},
+		"is-symbol": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+			"integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
 			"dev": true
 		},
 		"is-typedarray": {
@@ -3889,6 +4496,12 @@
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
 			"integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+		},
+		"is-windows": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+			"dev": true
 		},
 		"isarray": {
 			"version": "1.0.0",
@@ -3918,20 +4531,20 @@
 			"resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
 			"integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
 			"requires": {
-				"abbrev": "1.0.9",
-				"async": "1.5.2",
-				"escodegen": "1.8.1",
-				"esprima": "2.7.3",
-				"glob": "5.0.15",
-				"handlebars": "4.0.11",
-				"js-yaml": "3.10.0",
-				"mkdirp": "0.5.1",
-				"nopt": "3.0.6",
-				"once": "1.4.0",
-				"resolve": "1.1.7",
-				"supports-color": "3.2.3",
-				"which": "1.3.0",
-				"wordwrap": "1.0.0"
+				"abbrev": "1.0.x",
+				"async": "1.x",
+				"escodegen": "1.8.x",
+				"esprima": "2.7.x",
+				"glob": "^5.0.15",
+				"handlebars": "^4.0.1",
+				"js-yaml": "3.x",
+				"mkdirp": "0.5.x",
+				"nopt": "3.x",
+				"once": "1.x",
+				"resolve": "1.1.x",
+				"supports-color": "^3.1.0",
+				"which": "^1.1.1",
+				"wordwrap": "^1.0.0"
 			},
 			"dependencies": {
 				"esprima": {
@@ -3949,7 +4562,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				},
 				"wordwrap": {
@@ -3964,17 +4577,17 @@
 			"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.2.1.tgz",
 			"integrity": "sha512-oFCwXvd65amgaPCzqrR+a2XjanS1MvpXN6l/MlMUTv6uiA1NOgGX+I0uyq8Lg3GDxsxPsaP1049krz3hIJ5+KA==",
 			"requires": {
-				"async": "2.6.0",
-				"fileset": "2.0.3",
-				"istanbul-lib-coverage": "1.1.1",
-				"istanbul-lib-hook": "1.1.0",
-				"istanbul-lib-instrument": "1.9.1",
-				"istanbul-lib-report": "1.1.2",
-				"istanbul-lib-source-maps": "1.2.2",
-				"istanbul-reports": "1.1.3",
-				"js-yaml": "3.10.0",
-				"mkdirp": "0.5.1",
-				"once": "1.4.0"
+				"async": "^2.1.4",
+				"fileset": "^2.0.2",
+				"istanbul-lib-coverage": "^1.1.1",
+				"istanbul-lib-hook": "^1.1.0",
+				"istanbul-lib-instrument": "^1.9.1",
+				"istanbul-lib-report": "^1.1.2",
+				"istanbul-lib-source-maps": "^1.2.2",
+				"istanbul-reports": "^1.1.3",
+				"js-yaml": "^3.7.0",
+				"mkdirp": "^0.5.1",
+				"once": "^1.4.0"
 			},
 			"dependencies": {
 				"async": {
@@ -3982,7 +4595,7 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
 					"integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
 					"requires": {
-						"lodash": "4.17.4"
+						"lodash": "^4.14.0"
 					}
 				}
 			}
@@ -3997,7 +4610,7 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
 			"integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
 			"requires": {
-				"append-transform": "0.4.0"
+				"append-transform": "^0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -4005,13 +4618,13 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz",
 			"integrity": "sha512-RQmXeQ7sphar7k7O1wTNzVczF9igKpaeGQAG9qR2L+BS4DCJNTI9nytRmIVYevwO0bbq+2CXvJmYDuz0gMrywA==",
 			"requires": {
-				"babel-generator": "6.26.0",
-				"babel-template": "6.26.0",
-				"babel-traverse": "6.26.0",
-				"babel-types": "6.26.0",
-				"babylon": "6.18.0",
-				"istanbul-lib-coverage": "1.1.1",
-				"semver": "5.4.1"
+				"babel-generator": "^6.18.0",
+				"babel-template": "^6.16.0",
+				"babel-traverse": "^6.18.0",
+				"babel-types": "^6.18.0",
+				"babylon": "^6.18.0",
+				"istanbul-lib-coverage": "^1.1.1",
+				"semver": "^5.3.0"
 			}
 		},
 		"istanbul-lib-report": {
@@ -4019,10 +4632,10 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
 			"integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
 			"requires": {
-				"istanbul-lib-coverage": "1.1.1",
-				"mkdirp": "0.5.1",
-				"path-parse": "1.0.5",
-				"supports-color": "3.2.3"
+				"istanbul-lib-coverage": "^1.1.1",
+				"mkdirp": "^0.5.1",
+				"path-parse": "^1.0.5",
+				"supports-color": "^3.1.2"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -4030,7 +4643,7 @@
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"requires": {
-						"has-flag": "1.0.0"
+						"has-flag": "^1.0.0"
 					}
 				}
 			}
@@ -4040,11 +4653,11 @@
 			"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
 			"integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
 			"requires": {
-				"debug": "3.1.0",
-				"istanbul-lib-coverage": "1.1.1",
-				"mkdirp": "0.5.1",
-				"rimraf": "2.6.2",
-				"source-map": "0.5.7"
+				"debug": "^3.1.0",
+				"istanbul-lib-coverage": "^1.1.1",
+				"mkdirp": "^0.5.1",
+				"rimraf": "^2.6.1",
+				"source-map": "^0.5.3"
 			},
 			"dependencies": {
 				"debug": {
@@ -4060,12 +4673,12 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"minimatch": {
@@ -4073,7 +4686,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"rimraf": {
@@ -4081,7 +4694,7 @@
 					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"requires": {
-						"glob": "7.1.2"
+						"glob": "^7.0.5"
 					}
 				}
 			}
@@ -4091,22 +4704,38 @@
 			"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
 			"integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
 			"requires": {
-				"handlebars": "4.0.11"
+				"handlebars": "^4.0.3"
 			}
 		},
 		"jest": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest/-/jest-21.2.1.tgz",
-			"integrity": "sha512-mXN0ppPvWYoIcC+R+ctKxAJ28xkt/Z5Js875padm4GbgUn6baeR5N4Ng6LjatIRpUQDZVJABT7Y4gucFjPryfw==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest/-/jest-23.2.0.tgz",
+			"integrity": "sha1-govzGgltRdzwaCTR6gMBOve8/CA=",
 			"dev": true,
 			"requires": {
-				"jest-cli": "21.2.1"
+				"import-local": "^1.0.0",
+				"jest-cli": "^23.2.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+					"integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+					"dev": true
+				},
+				"acorn-globals": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+					"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+					"dev": true,
+					"requires": {
+						"acorn": "^5.0.0"
+					}
+				},
 				"ansi-escapes": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
-					"integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+					"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
 					"dev": true
 				},
 				"ansi-regex": {
@@ -4116,76 +4745,156 @@
 					"dev": true
 				},
 				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
+					}
+				},
+				"append-transform": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/append-transform/-/append-transform-1.0.0.tgz",
+					"integrity": "sha512-P009oYkeHyU742iSZJzZZywj4QRJdnTWffaKuJQLablCZ1uz6/cW4yaRgcDaoQ+uwOxxnt0gRUcwfsNP2ri0gw==",
+					"dev": true,
+					"requires": {
+						"default-require-extensions": "^2.0.0"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"async": {
+					"version": "2.6.1",
+					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+					"dev": true,
+					"requires": {
+						"lodash": "^4.17.10"
 					}
 				},
 				"babel-core": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-					"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-generator": "6.26.0",
-						"babel-helpers": "6.24.1",
-						"babel-messages": "6.23.0",
-						"babel-register": "6.26.0",
-						"babel-runtime": "6.26.0",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"convert-source-map": "1.5.0",
-						"debug": "2.6.9",
-						"json5": "0.5.1",
-						"lodash": "4.17.4",
-						"minimatch": "3.0.4",
-						"path-is-absolute": "1.0.1",
-						"private": "0.1.8",
-						"slash": "1.0.0",
-						"source-map": "0.5.7"
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+							"dev": true,
+							"requires": {
+								"ms": "2.0.0"
+							}
+						}
 					}
 				},
 				"babel-jest": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
-					"integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.2.0.tgz",
+					"integrity": "sha1-FKnWo/QSLf6mBp03CFrfJqU6Tbo=",
 					"dev": true,
 					"requires": {
-						"babel-plugin-istanbul": "4.1.5",
-						"babel-preset-jest": "21.2.0"
+						"babel-plugin-istanbul": "^4.1.6",
+						"babel-preset-jest": "^23.2.0"
 					}
 				},
 				"babel-plugin-istanbul": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
-					"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+					"version": "4.1.6",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+					"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"istanbul-lib-instrument": "1.9.1",
-						"test-exclude": "4.1.1"
+						"babel-plugin-syntax-object-rest-spread": "^6.13.0",
+						"find-up": "^2.1.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"test-exclude": "^4.2.1"
 					}
 				},
 				"babel-plugin-jest-hoist": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
-					"integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
+					"integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
 					"dev": true
 				},
 				"babel-preset-jest": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
-					"integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
+					"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
 					"dev": true,
 					"requires": {
-						"babel-plugin-jest-hoist": "21.2.0",
-						"babel-plugin-syntax-object-rest-spread": "6.13.0"
+						"babel-plugin-jest-hoist": "^23.2.0",
+						"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"browser-resolve": {
+					"version": "1.11.3",
+					"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+					"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+					"dev": true,
+					"requires": {
+						"resolve": "1.1.7"
 					}
 				},
 				"bser": {
@@ -4194,7 +4903,7 @@
 					"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 					"dev": true,
 					"requires": {
-						"node-int64": "0.4.0"
+						"node-int64": "^0.4.0"
 					}
 				},
 				"callsites": {
@@ -4210,51 +4919,221 @@
 					"dev": true
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
+					}
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+					"dev": true
+				},
+				"cssstyle": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
+					"integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+					"dev": true,
+					"requires": {
+						"cssom": "0.3.x"
+					}
+				},
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"dev": true,
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"default-require-extensions": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
+					"integrity": "sha1-9fj7sYp9bVCyH2QfZJ67Uiz+JPc=",
+					"dev": true,
+					"requires": {
+						"strip-bom": "^3.0.0"
+					}
+				},
+				"escodegen": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
+					"integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+					"dev": true,
+					"requires": {
+						"esprima": "^3.1.3",
+						"estraverse": "^4.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
 					},
 					"dependencies": {
-						"ansi-regex": {
-							"version": "2.1.1",
-							"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-							"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-							"dev": true
-						},
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"debug": {
+							"version": "2.6.9",
+							"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+							"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"ms": "2.0.0"
 							}
 						},
-						"strip-ansi": {
-							"version": "3.0.1",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-							"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"ansi-regex": "2.1.1"
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -4265,7 +5144,30 @@
 					"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 					"dev": true,
 					"requires": {
-						"bser": "2.0.0"
+						"bser": "^2.0.0"
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
 					}
 				},
 				"find-up": {
@@ -4274,7 +5176,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"glob": {
@@ -4283,237 +5185,460 @@
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
-				"jest-changed-files": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-21.2.0.tgz",
-					"integrity": "sha512-+lCNP1IZLwN1NOIvBcV5zEL6GENK6TXrDj4UxWIeLvIsIDa+gf6J7hkqsW2qVVt/wvH65rVvcPwqXdps5eclTQ==",
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"throat": "4.1.0"
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"istanbul-api": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-1.3.1.tgz",
+					"integrity": "sha512-duj6AlLcsWNwUpfyfHt0nWIeRiZpuShnP40YTxOGQgtaN8fd6JYSxsvxUphTDy8V5MfDXo4s/xVCIIvVCO808g==",
+					"dev": true,
+					"requires": {
+						"async": "^2.1.4",
+						"compare-versions": "^3.1.0",
+						"fileset": "^2.0.2",
+						"istanbul-lib-coverage": "^1.2.0",
+						"istanbul-lib-hook": "^1.2.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"istanbul-lib-report": "^1.1.4",
+						"istanbul-lib-source-maps": "^1.2.4",
+						"istanbul-reports": "^1.3.0",
+						"js-yaml": "^3.7.0",
+						"mkdirp": "^0.5.1",
+						"once": "^1.4.0"
+					}
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+					"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+					"dev": true
+				},
+				"istanbul-lib-hook": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.2.1.tgz",
+					"integrity": "sha512-eLAMkPG9FU0v5L02lIkcj/2/Zlz9OuluaXikdr5iStk8FDbSwAixTK9TkYxbF0eNnzAJTwM2fkV2A1tpsIp4Jg==",
+					"dev": true,
+					"requires": {
+						"append-transform": "^1.0.0"
+					}
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.10.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+					"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+					"dev": true,
+					"requires": {
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
+					}
+				},
+				"istanbul-lib-report": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz",
+					"integrity": "sha512-Azqvq5tT0U09nrncK3q82e/Zjkxa4tkFZv7E6VcqP0QCPn6oNljDPfrZEC/umNXds2t7b8sRJfs6Kmpzt8m2kA==",
+					"dev": true,
+					"requires": {
+						"istanbul-lib-coverage": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"path-parse": "^1.0.5",
+						"supports-color": "^3.1.2"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+							"integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+							"dev": true
+						},
+						"supports-color": {
+							"version": "3.2.3",
+							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+							"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+							"dev": true,
+							"requires": {
+								"has-flag": "^1.0.0"
+							}
+						}
+					}
+				},
+				"istanbul-lib-source-maps": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.5.tgz",
+					"integrity": "sha512-8O2T/3VhrQHn0XcJbP1/GN7kXMiRAlPi+fj3uEHrjBD8Oz7Py0prSC25C09NuAZS6bgW1NNKAvCSHZXB0irSGA==",
+					"dev": true,
+					"requires": {
+						"debug": "^3.1.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"mkdirp": "^0.5.1",
+						"rimraf": "^2.6.1",
+						"source-map": "^0.5.3"
+					}
+				},
+				"istanbul-reports": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.3.0.tgz",
+					"integrity": "sha512-y2Z2IMqE1gefWUaVjrBm0mSKvUkaBy9Vqz8iwr/r40Y9hBbIteH5wqHG/9DLTfJ9xUnUT2j7A3+VVJ6EaYBllA==",
+					"dev": true,
+					"requires": {
+						"handlebars": "^4.0.3"
+					}
+				},
+				"jest-changed-files": {
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-23.2.0.tgz",
+					"integrity": "sha1-oUWm5LZtASn8fJnO4TTck3pkPZw=",
+					"dev": true,
+					"requires": {
+						"throat": "^4.0.0"
 					}
 				},
 				"jest-cli": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-21.2.1.tgz",
-					"integrity": "sha512-T1BzrbFxDIW/LLYQqVfo94y/hhaj1NzVQkZgBumAC+sxbjMROI7VkihOdxNR758iYbQykL2ZOWUBurFgkQrzdg==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.2.0.tgz",
+					"integrity": "sha1-O1Q6PaUUXdiTeTEBcoI3n8aWxFs=",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "3.0.0",
-						"chalk": "2.3.0",
-						"glob": "7.1.2",
-						"graceful-fs": "4.1.11",
-						"is-ci": "1.0.10",
-						"istanbul-api": "1.2.1",
-						"istanbul-lib-coverage": "1.1.1",
-						"istanbul-lib-instrument": "1.9.1",
-						"istanbul-lib-source-maps": "1.2.2",
-						"jest-changed-files": "21.2.0",
-						"jest-config": "21.2.1",
-						"jest-environment-jsdom": "21.2.1",
-						"jest-haste-map": "21.2.0",
-						"jest-message-util": "21.2.1",
-						"jest-regex-util": "21.2.0",
-						"jest-resolve-dependencies": "21.2.0",
-						"jest-runner": "21.2.1",
-						"jest-runtime": "21.2.1",
-						"jest-snapshot": "21.2.1",
-						"jest-util": "21.2.1",
-						"micromatch": "2.3.11",
-						"node-notifier": "5.1.2",
-						"pify": "3.0.0",
-						"slash": "1.0.0",
-						"string-length": "2.0.0",
-						"strip-ansi": "4.0.0",
-						"which": "1.3.0",
-						"worker-farm": "1.5.2",
-						"yargs": "9.0.1"
+						"ansi-escapes": "^3.0.0",
+						"chalk": "^2.0.1",
+						"exit": "^0.1.2",
+						"glob": "^7.1.2",
+						"graceful-fs": "^4.1.11",
+						"import-local": "^1.0.0",
+						"is-ci": "^1.0.10",
+						"istanbul-api": "^1.3.1",
+						"istanbul-lib-coverage": "^1.2.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"istanbul-lib-source-maps": "^1.2.4",
+						"jest-changed-files": "^23.2.0",
+						"jest-config": "^23.2.0",
+						"jest-environment-jsdom": "^23.2.0",
+						"jest-get-type": "^22.1.0",
+						"jest-haste-map": "^23.2.0",
+						"jest-message-util": "^23.2.0",
+						"jest-regex-util": "^23.0.0",
+						"jest-resolve-dependencies": "^23.2.0",
+						"jest-runner": "^23.2.0",
+						"jest-runtime": "^23.2.0",
+						"jest-snapshot": "^23.2.0",
+						"jest-util": "^23.2.0",
+						"jest-validate": "^23.2.0",
+						"jest-watcher": "^23.2.0",
+						"jest-worker": "^23.2.0",
+						"micromatch": "^3.1.10",
+						"node-notifier": "^5.2.1",
+						"prompts": "^0.1.9",
+						"realpath-native": "^1.0.0",
+						"rimraf": "^2.5.4",
+						"slash": "^1.0.0",
+						"string-length": "^2.0.0",
+						"strip-ansi": "^4.0.0",
+						"which": "^1.2.12",
+						"yargs": "^11.0.0"
 					}
 				},
 				"jest-config": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz",
-					"integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.2.0.tgz",
+					"integrity": "sha1-0vtVb9WioZw561bROdzKXa0qHIg=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"glob": "7.1.2",
-						"jest-environment-jsdom": "21.2.1",
-						"jest-environment-node": "21.2.1",
-						"jest-get-type": "21.2.0",
-						"jest-jasmine2": "21.2.1",
-						"jest-regex-util": "21.2.0",
-						"jest-resolve": "21.2.0",
-						"jest-util": "21.2.1",
-						"jest-validate": "21.2.1",
-						"pretty-format": "21.2.1"
+						"babel-core": "^6.0.0",
+						"babel-jest": "^23.2.0",
+						"chalk": "^2.0.1",
+						"glob": "^7.1.1",
+						"jest-environment-jsdom": "^23.2.0",
+						"jest-environment-node": "^23.2.0",
+						"jest-get-type": "^22.1.0",
+						"jest-jasmine2": "^23.2.0",
+						"jest-regex-util": "^23.0.0",
+						"jest-resolve": "^23.2.0",
+						"jest-util": "^23.2.0",
+						"jest-validate": "^23.2.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-diff": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
-					"integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
+					"integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"diff": "3.4.0",
-						"jest-get-type": "21.2.0",
-						"pretty-format": "21.2.1"
+						"chalk": "^2.0.1",
+						"diff": "^3.2.0",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-environment-jsdom": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz",
-					"integrity": "sha512-mecaeNh0eWmzNrUNMWARysc0E9R96UPBamNiOCYL28k7mksb1d0q6DD38WKP7ABffjnXyUWJPVaWRgUOivwXwg==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.2.0.tgz",
+					"integrity": "sha1-NjRgOgipdbDKimWDIPVqVKjgRVg=",
 					"dev": true,
 					"requires": {
-						"jest-mock": "21.2.0",
-						"jest-util": "21.2.1",
-						"jsdom": "9.12.0"
+						"jest-mock": "^23.2.0",
+						"jest-util": "^23.2.0",
+						"jsdom": "^11.5.1"
 					}
 				},
 				"jest-environment-node": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz",
-					"integrity": "sha512-R211867wx9mVBVHzrjGRGTy5cd05K7eqzQl/WyZixR/VkJ4FayS8qkKXZyYnwZi6Rxo6WEV81cDbiUx/GfuLNw==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.2.0.tgz",
+					"integrity": "sha1-tv5BNy44IJO7bz2b32wcTsClDxg=",
 					"dev": true,
 					"requires": {
-						"jest-mock": "21.2.0",
-						"jest-util": "21.2.1"
+						"jest-mock": "^23.2.0",
+						"jest-util": "^23.2.0"
 					}
 				},
 				"jest-haste-map": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
-					"integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.2.0.tgz",
+					"integrity": "sha1-0Qy6wAfGlZSMjvGCGisu0tTy1Ng=",
 					"dev": true,
 					"requires": {
-						"fb-watchman": "2.0.0",
-						"graceful-fs": "4.1.11",
-						"jest-docblock": "21.2.0",
-						"micromatch": "2.3.11",
-						"sane": "2.2.0",
-						"worker-farm": "1.5.2"
+						"fb-watchman": "^2.0.0",
+						"graceful-fs": "^4.1.11",
+						"jest-docblock": "^23.2.0",
+						"jest-serializer": "^23.0.1",
+						"jest-worker": "^23.2.0",
+						"micromatch": "^3.1.10",
+						"sane": "^2.0.0"
 					}
 				},
 				"jest-jasmine2": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz",
-					"integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.2.0.tgz",
+					"integrity": "sha1-qmcM2x5NX47HdMlN2l4QX+M9i7Q=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"expect": "21.2.1",
-						"graceful-fs": "4.1.11",
-						"jest-diff": "21.2.1",
-						"jest-matcher-utils": "21.2.1",
-						"jest-message-util": "21.2.1",
-						"jest-snapshot": "21.2.1",
-						"p-cancelable": "0.3.0"
+						"chalk": "^2.0.1",
+						"co": "^4.6.0",
+						"expect": "^23.2.0",
+						"is-generator-fn": "^1.0.0",
+						"jest-diff": "^23.2.0",
+						"jest-each": "^23.2.0",
+						"jest-matcher-utils": "^23.2.0",
+						"jest-message-util": "^23.2.0",
+						"jest-snapshot": "^23.2.0",
+						"jest-util": "^23.2.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-matcher-utils": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
-					"integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
+					"integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"jest-get-type": "21.2.0",
-						"pretty-format": "21.2.1"
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-mock": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz",
-					"integrity": "sha512-aZDfyVf0LEoABWiY6N0d+O963dUQSyUa4qgzurHR3TBDPen0YxKCJ6l2i7lQGh1tVdsuvdrCZ4qPj+A7PievCw==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
+					"integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=",
 					"dev": true
 				},
 				"jest-resolve": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz",
-					"integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.2.0.tgz",
+					"integrity": "sha1-oHkK1aO5kAKrTb/L+Nni1qabPZk=",
 					"dev": true,
 					"requires": {
-						"browser-resolve": "1.11.2",
-						"chalk": "2.3.0",
-						"is-builtin-module": "1.0.0"
+						"browser-resolve": "^1.11.3",
+						"chalk": "^2.0.1",
+						"realpath-native": "^1.0.0"
 					}
 				},
 				"jest-resolve-dependencies": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz",
-					"integrity": "sha512-ok8ybRFU5ScaAcfufIQrCbdNJSRZ85mkxJ1EhUp8Bhav1W1/jv/rl1Q6QoVQHObNxmKnbHVKrfLZbCbOsXQ+bQ==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-23.2.0.tgz",
+					"integrity": "sha1-bfjVcJxkBmOc0H9Uv/B04BtcBFg=",
 					"dev": true,
 					"requires": {
-						"jest-regex-util": "21.2.0"
+						"jest-regex-util": "^23.0.0",
+						"jest-snapshot": "^23.2.0"
 					}
 				},
 				"jest-runtime": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz",
-					"integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.2.0.tgz",
+					"integrity": "sha1-YtywF2ahxMZGltwJAgnnbOGq3Lw=",
 					"dev": true,
 					"requires": {
-						"babel-core": "6.26.0",
-						"babel-jest": "21.2.0",
-						"babel-plugin-istanbul": "4.1.5",
-						"chalk": "2.3.0",
-						"convert-source-map": "1.5.0",
-						"graceful-fs": "4.1.11",
-						"jest-config": "21.2.1",
-						"jest-haste-map": "21.2.0",
-						"jest-regex-util": "21.2.0",
-						"jest-resolve": "21.2.0",
-						"jest-util": "21.2.1",
-						"json-stable-stringify": "1.0.1",
-						"micromatch": "2.3.11",
-						"slash": "1.0.0",
+						"babel-core": "^6.0.0",
+						"babel-plugin-istanbul": "^4.1.6",
+						"chalk": "^2.0.1",
+						"convert-source-map": "^1.4.0",
+						"exit": "^0.1.2",
+						"fast-json-stable-stringify": "^2.0.0",
+						"graceful-fs": "^4.1.11",
+						"jest-config": "^23.2.0",
+						"jest-haste-map": "^23.2.0",
+						"jest-message-util": "^23.2.0",
+						"jest-regex-util": "^23.0.0",
+						"jest-resolve": "^23.2.0",
+						"jest-snapshot": "^23.2.0",
+						"jest-util": "^23.2.0",
+						"jest-validate": "^23.2.0",
+						"micromatch": "^3.1.10",
+						"realpath-native": "^1.0.0",
+						"slash": "^1.0.0",
 						"strip-bom": "3.0.0",
-						"write-file-atomic": "2.3.0",
-						"yargs": "9.0.1"
+						"write-file-atomic": "^2.1.0",
+						"yargs": "^11.0.0"
 					}
 				},
 				"jest-snapshot": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
-					"integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.2.0.tgz",
+					"integrity": "sha1-x6PQFxd7utYMillYac+QqHguan4=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"jest-diff": "21.2.1",
-						"jest-matcher-utils": "21.2.1",
-						"mkdirp": "0.5.1",
-						"natural-compare": "1.4.0",
-						"pretty-format": "21.2.1"
+						"chalk": "^2.0.1",
+						"jest-diff": "^23.2.0",
+						"jest-matcher-utils": "^23.2.0",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-util": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz",
-					"integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.2.0.tgz",
+					"integrity": "sha1-YrdwdXaW2W4JSgS48cNzylClqy4=",
 					"dev": true,
 					"requires": {
-						"callsites": "2.0.0",
-						"chalk": "2.3.0",
-						"graceful-fs": "4.1.11",
-						"jest-message-util": "21.2.1",
-						"jest-mock": "21.2.0",
-						"jest-validate": "21.2.1",
-						"mkdirp": "0.5.1"
+						"callsites": "^2.0.0",
+						"chalk": "^2.0.1",
+						"graceful-fs": "^4.1.11",
+						"is-ci": "^1.0.10",
+						"jest-message-util": "^23.2.0",
+						"mkdirp": "^0.5.1",
+						"slash": "^1.0.0",
+						"source-map": "^0.6.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true
+						}
+					}
+				},
+				"jsdom": {
+					"version": "11.11.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
+					"integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+					"dev": true,
+					"requires": {
+						"abab": "^1.0.4",
+						"acorn": "^5.3.0",
+						"acorn-globals": "^4.1.0",
+						"array-equal": "^1.0.0",
+						"cssom": ">= 0.3.2 < 0.4.0",
+						"cssstyle": ">= 0.3.1 < 0.4.0",
+						"data-urls": "^1.0.0",
+						"domexception": "^1.0.0",
+						"escodegen": "^1.9.0",
+						"html-encoding-sniffer": "^1.0.2",
+						"left-pad": "^1.2.0",
+						"nwsapi": "^2.0.0",
+						"parse5": "4.0.0",
+						"pn": "^1.1.0",
+						"request": "^2.83.0",
+						"request-promise-native": "^1.0.5",
+						"sax": "^1.2.4",
+						"symbol-tree": "^3.2.2",
+						"tough-cookie": "^2.3.3",
+						"w3c-hr-time": "^1.0.1",
+						"webidl-conversions": "^4.0.2",
+						"whatwg-encoding": "^1.0.3",
+						"whatwg-mimetype": "^2.1.0",
+						"whatwg-url": "^6.4.1",
+						"ws": "^4.0.0",
+						"xml-name-validator": "^3.0.0"
 					}
 				},
 				"json5": {
@@ -4522,24 +5647,31 @@
 					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 					"dev": true
 				},
-				"load-json-file": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"strip-bom": "3.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
-						}
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"minimatch": {
@@ -4548,19 +5680,19 @@
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"node-notifier": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.1.2.tgz",
-					"integrity": "sha1-L6nhJgX6EACdRFSdb82KY93g5P8=",
+					"version": "5.2.1",
+					"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
+					"integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
 					"dev": true,
 					"requires": {
-						"growly": "1.3.0",
-						"semver": "5.4.1",
-						"shellwords": "0.1.1",
-						"which": "1.3.0"
+						"growly": "^1.3.0",
+						"semver": "^5.4.1",
+						"shellwords": "^0.1.1",
+						"which": "^1.3.0"
 					}
 				},
 				"os-locale": {
@@ -4569,69 +5701,63 @@
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
-				"path-type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"dev": true,
-					"requires": {
-						"pify": "2.3.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
-						}
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+				"parse5": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-					"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0",
-						"ansi-styles": "3.2.0"
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
 					}
 				},
-				"read-pkg": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
+				},
+				"rimraf": {
+					"version": "2.6.2",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"dev": true,
 					"requires": {
-						"load-json-file": "2.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "2.0.0"
+						"glob": "^7.0.5"
 					}
 				},
 				"sane": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz",
-					"integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+					"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 					"dev": true,
 					"requires": {
-						"anymatch": "1.3.2",
-						"exec-sh": "0.2.1",
-						"fb-watchman": "2.0.0",
-						"fsevents": "1.1.3",
-						"minimatch": "3.0.4",
-						"minimist": "1.2.0",
-						"walker": "1.0.7",
-						"watch": "0.18.0"
+						"anymatch": "^2.0.0",
+						"capture-exit": "^1.2.0",
+						"exec-sh": "^0.2.0",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^1.2.3",
+						"micromatch": "^3.1.4",
+						"minimist": "^1.1.1",
+						"walker": "~1.0.5",
+						"watch": "~0.18.0"
 					}
 				},
 				"string-width": {
@@ -4640,16 +5766,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
-					},
-					"dependencies": {
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-							"dev": true
-						}
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4658,7 +5776,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -4668,25 +5786,25 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"test-exclude": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-					"integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+					"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
 					"dev": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "2.3.11",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
 					}
 				},
 				"throat": {
@@ -4695,14 +5813,34 @@
 					"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 					"dev": true
 				},
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
 				"watch": {
 					"version": "0.18.0",
 					"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
 					"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 					"dev": true,
 					"requires": {
-						"exec-sh": "0.2.1",
-						"minimist": "1.2.0"
+						"exec-sh": "^0.2.0",
+						"minimist": "^1.2.0"
+					}
+				},
+				"whatwg-url": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
 					}
 				},
 				"which-module": {
@@ -4717,51 +5855,44 @@
 					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"signal-exit": "3.0.2"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
 					}
 				},
+				"xml-name-validator": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+					"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+					"dev": true
+				},
 				"yargs": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-					"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
-					},
-					"dependencies": {
-						"read-pkg-up": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-							"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-							"dev": true,
-							"requires": {
-								"find-up": "2.1.0",
-								"read-pkg": "2.0.0"
-							}
-						}
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					}
 				},
 				"yargs-parser": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -4776,15 +5907,15 @@
 			"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-17.0.3.tgz",
 			"integrity": "sha1-tu112Q0JC3Mf2JQjGQTK231aXfI=",
 			"requires": {
-				"chalk": "1.1.3",
-				"istanbul": "0.4.5",
-				"jest-environment-jsdom": "17.0.2",
-				"jest-environment-node": "17.0.2",
-				"jest-jasmine2": "17.0.3",
-				"jest-mock": "17.0.2",
-				"jest-resolve": "17.0.3",
-				"jest-util": "17.0.2",
-				"json-stable-stringify": "1.0.1"
+				"chalk": "^1.1.1",
+				"istanbul": "^0.4.5",
+				"jest-environment-jsdom": "^17.0.2",
+				"jest-environment-node": "^17.0.2",
+				"jest-jasmine2": "^17.0.3",
+				"jest-mock": "^17.0.2",
+				"jest-resolve": "^17.0.3",
+				"jest-util": "^17.0.2",
+				"json-stable-stringify": "^1.0.0"
 			}
 		},
 		"jest-diff": {
@@ -4792,26 +5923,92 @@
 			"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-17.0.3.tgz",
 			"integrity": "sha1-j7Me+rOzFNe2G3tmsL3qYX7xwC8=",
 			"requires": {
-				"chalk": "1.1.3",
-				"diff": "3.4.0",
-				"jest-matcher-utils": "17.0.3",
-				"pretty-format": "4.2.3"
+				"chalk": "^1.1.3",
+				"diff": "^3.0.0",
+				"jest-matcher-utils": "^17.0.3",
+				"pretty-format": "~4.2.1"
 			}
 		},
 		"jest-docblock": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
-			"integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
-			"dev": true
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-23.2.0.tgz",
+			"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
+			"dev": true,
+			"requires": {
+				"detect-newline": "^2.1.0"
+			}
+		},
+		"jest-each": {
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-each/-/jest-each-23.2.0.tgz",
+			"integrity": "sha1-pAD4HIVwg/UMT1M5mxCfEgI/sZ0=",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.1",
+				"pretty-format": "^23.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
 		},
 		"jest-environment-jsdom": {
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-17.0.2.tgz",
 			"integrity": "sha1-owmNwpgG1AgCxStiuEiraqAP26A=",
 			"requires": {
-				"jest-mock": "17.0.2",
-				"jest-util": "17.0.2",
-				"jsdom": "9.12.0"
+				"jest-mock": "^17.0.2",
+				"jest-util": "^17.0.2",
+				"jsdom": "^9.8.1"
 			}
 		},
 		"jest-environment-node": {
@@ -4819,8 +6016,8 @@
 			"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-17.0.2.tgz",
 			"integrity": "sha1-r/YTP0yi+t3MWwzn0lzsg+FthGM=",
 			"requires": {
-				"jest-mock": "17.0.2",
-				"jest-util": "17.0.2"
+				"jest-mock": "^17.0.2",
+				"jest-util": "^17.0.2"
 			}
 		},
 		"jest-file-exists": {
@@ -4829,9 +6026,9 @@
 			"integrity": "sha1-f2Prc6HEOhP0Yb4mF2i0WvLN0Wk="
 		},
 		"jest-get-type": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
-			"integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+			"version": "22.4.3",
+			"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+			"integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
 			"dev": true
 		},
 		"jest-haste-map": {
@@ -4839,11 +6036,11 @@
 			"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-17.0.3.tgz",
 			"integrity": "sha1-UjJ4PnBXche2sX0qHBdmY3odL70=",
 			"requires": {
-				"fb-watchman": "1.9.2",
-				"graceful-fs": "4.1.11",
-				"multimatch": "2.1.0",
-				"sane": "1.4.1",
-				"worker-farm": "1.5.2"
+				"fb-watchman": "^1.9.0",
+				"graceful-fs": "^4.1.6",
+				"multimatch": "^2.1.0",
+				"sane": "~1.4.1",
+				"worker-farm": "^1.3.1"
 			}
 		},
 		"jest-jasmine2": {
@@ -4851,10 +6048,46 @@
 			"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-17.0.3.tgz",
 			"integrity": "sha1-1DNrifOtKIJpocjiv8GA3PicatE=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"jest-matchers": "17.0.3",
-				"jest-snapshot": "17.0.3",
-				"jest-util": "17.0.2"
+				"graceful-fs": "^4.1.6",
+				"jest-matchers": "^17.0.3",
+				"jest-snapshot": "^17.0.3",
+				"jest-util": "^17.0.2"
+			}
+		},
+		"jest-leak-detector": {
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-23.2.0.tgz",
+			"integrity": "sha1-wonZYdxjjxQ1fU75bgQx7MGqN30=",
+			"dev": true,
+			"requires": {
+				"pretty-format": "^23.2.0"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+					"integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"pretty-format": {
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
+					}
+				}
 			}
 		},
 		"jest-matcher-utils": {
@@ -4862,8 +6095,8 @@
 			"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-17.0.3.tgz",
 			"integrity": "sha1-8Qjkm5VuFSxmJtzAq6hk9Zq3sNM=",
 			"requires": {
-				"chalk": "1.1.3",
-				"pretty-format": "4.2.3"
+				"chalk": "^1.1.3",
+				"pretty-format": "~4.2.1"
 			}
 		},
 		"jest-matchers": {
@@ -4871,55 +6104,331 @@
 			"resolved": "https://registry.npmjs.org/jest-matchers/-/jest-matchers-17.0.3.tgz",
 			"integrity": "sha1-iLlTSMkZND24bQjxI1SoZQrn7d8=",
 			"requires": {
-				"jest-diff": "17.0.3",
-				"jest-matcher-utils": "17.0.3",
-				"jest-util": "17.0.2"
+				"jest-diff": "^17.0.3",
+				"jest-matcher-utils": "^17.0.3",
+				"jest-util": "^17.0.2"
 			}
 		},
 		"jest-message-util": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-21.2.1.tgz",
-			"integrity": "sha512-EbC1X2n0t9IdeMECJn2BOg7buOGivCvVNjqKMXTzQOu7uIfLml+keUfCALDh8o4rbtndIeyGU8/BKfoTr/LVDQ==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-23.2.0.tgz",
+			"integrity": "sha1-WR6BSP/2nPibBBSAnHIXVuvv50Q=",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.0",
-				"micromatch": "2.3.11",
-				"slash": "1.0.0"
+				"@babel/code-frame": "^7.0.0-beta.35",
+				"chalk": "^2.0.1",
+				"micromatch": "^3.1.10",
+				"slash": "^1.0.0",
+				"stack-utils": "^1.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
+					}
+				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
 					}
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
 					}
 				},
 				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
-				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+					"dev": true,
+					"requires": {
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
+					}
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -4930,9 +6439,9 @@
 			"integrity": "sha1-Pf6SIa/ZqmGz2ZkoQIE6NYuy9Ck="
 		},
 		"jest-regex-util": {
-			"version": "21.2.0",
-			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-21.2.0.tgz",
-			"integrity": "sha512-BKQ1F83EQy0d9Jen/mcVX7D+lUt2tthhK/2gDWRgLDJRNOdRgSp1iVqFxP8EN1ARuypvDflRfPzYT8fQnoBQFQ==",
+			"version": "23.0.0",
+			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.0.0.tgz",
+			"integrity": "sha1-3Vwf3gxG9DcTFM8Q96dRoj9Oj3Y=",
 			"dev": true
 		},
 		"jest-resolve": {
@@ -4940,10 +6449,10 @@
 			"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-17.0.3.tgz",
 			"integrity": "sha1-dpKnneKDGHQ3Xp1mS8eCwp5NomI=",
 			"requires": {
-				"browser-resolve": "1.11.2",
-				"jest-file-exists": "17.0.0",
-				"jest-haste-map": "17.0.3",
-				"resolve": "1.5.0"
+				"browser-resolve": "^1.11.2",
+				"jest-file-exists": "^17.0.0",
+				"jest-haste-map": "^17.0.3",
+				"resolve": "^1.1.6"
 			}
 		},
 		"jest-resolve-dependencies": {
@@ -4951,28 +6460,46 @@
 			"resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-17.0.3.tgz",
 			"integrity": "sha1-u9N/RkNwS5epgJJyEvOrErBuiJQ=",
 			"requires": {
-				"jest-file-exists": "17.0.0",
-				"jest-resolve": "17.0.3"
+				"jest-file-exists": "^17.0.0",
+				"jest-resolve": "^17.0.3"
 			}
 		},
 		"jest-runner": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-21.2.1.tgz",
-			"integrity": "sha512-Anb72BOQlHqF/zETqZ2K20dbYsnqW/nZO7jV8BYENl+3c44JhMrA8zd1lt52+N7ErnsQMd2HHKiVwN9GYSXmrg==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-23.2.0.tgz",
+			"integrity": "sha1-DZGWfqgvcrDHBZEJJghtIFXOda8=",
 			"dev": true,
 			"requires": {
-				"jest-config": "21.2.1",
-				"jest-docblock": "21.2.0",
-				"jest-haste-map": "21.2.0",
-				"jest-jasmine2": "21.2.1",
-				"jest-message-util": "21.2.1",
-				"jest-runtime": "21.2.1",
-				"jest-util": "21.2.1",
-				"pify": "3.0.0",
-				"throat": "4.1.0",
-				"worker-farm": "1.5.2"
+				"exit": "^0.1.2",
+				"graceful-fs": "^4.1.11",
+				"jest-config": "^23.2.0",
+				"jest-docblock": "^23.2.0",
+				"jest-haste-map": "^23.2.0",
+				"jest-jasmine2": "^23.2.0",
+				"jest-leak-detector": "^23.2.0",
+				"jest-message-util": "^23.2.0",
+				"jest-runtime": "^23.2.0",
+				"jest-util": "^23.2.0",
+				"jest-worker": "^23.2.0",
+				"source-map-support": "^0.5.6",
+				"throat": "^4.0.0"
 			},
 			"dependencies": {
+				"acorn": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+					"integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
+					"dev": true
+				},
+				"acorn-globals": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
+					"integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+					"dev": true,
+					"requires": {
+						"acorn": "^5.0.0"
+					}
+				},
 				"ansi-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
@@ -4980,76 +6507,127 @@
 					"dev": true
 				},
 				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
 				"babel-core": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-					"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 					"dev": true,
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-generator": "6.26.0",
-						"babel-helpers": "6.24.1",
-						"babel-messages": "6.23.0",
-						"babel-register": "6.26.0",
-						"babel-runtime": "6.26.0",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"convert-source-map": "1.5.0",
-						"debug": "2.6.9",
-						"json5": "0.5.1",
-						"lodash": "4.17.4",
-						"minimatch": "3.0.4",
-						"path-is-absolute": "1.0.1",
-						"private": "0.1.8",
-						"slash": "1.0.0",
-						"source-map": "0.5.7"
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
 					}
 				},
 				"babel-jest": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-21.2.0.tgz",
-					"integrity": "sha512-O0W2qLoWu1QOoOGgxiR2JID4O6WSpxPiQanrkyi9SSlM0PJ60Ptzlck47lhtnr9YZO3zYOsxHwnyeWJ6AffoBQ==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-23.2.0.tgz",
+					"integrity": "sha1-FKnWo/QSLf6mBp03CFrfJqU6Tbo=",
 					"dev": true,
 					"requires": {
-						"babel-plugin-istanbul": "4.1.5",
-						"babel-preset-jest": "21.2.0"
+						"babel-plugin-istanbul": "^4.1.6",
+						"babel-preset-jest": "^23.2.0"
 					}
 				},
 				"babel-plugin-istanbul": {
-					"version": "4.1.5",
-					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.5.tgz",
-					"integrity": "sha1-Z2DN2Xf0EdPhdbsGTyvDJ9mbK24=",
+					"version": "4.1.6",
+					"resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz",
+					"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 					"dev": true,
 					"requires": {
-						"find-up": "2.1.0",
-						"istanbul-lib-instrument": "1.9.1",
-						"test-exclude": "4.1.1"
+						"babel-plugin-syntax-object-rest-spread": "^6.13.0",
+						"find-up": "^2.1.0",
+						"istanbul-lib-instrument": "^1.10.1",
+						"test-exclude": "^4.2.1"
 					}
 				},
 				"babel-plugin-jest-hoist": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz",
-					"integrity": "sha512-yi5QuiVyyvhBUDLP4ButAnhYzkdrUwWDtvUJv71hjH3fclhnZg4HkDeqaitcR2dZZx/E67kGkRcPVjtVu+SJfQ==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz",
+					"integrity": "sha1-5h+uBaHKiAGq3uV6bWa4zvr0QWc=",
 					"dev": true
 				},
 				"babel-preset-jest": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-21.2.0.tgz",
-					"integrity": "sha512-hm9cBnr2h3J7yXoTtAVV0zg+3vg0Q/gT2GYuzlreTU0EPkJRtlNgKJJ3tBKEn0+VjAi3JykV6xCJkuUYttEEfA==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz",
+					"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
 					"dev": true,
 					"requires": {
-						"babel-plugin-jest-hoist": "21.2.0",
-						"babel-plugin-syntax-object-rest-spread": "6.13.0"
+						"babel-plugin-jest-hoist": "^23.2.0",
+						"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+					}
+				},
+				"braces": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+					"dev": true,
+					"requires": {
+						"arr-flatten": "^1.1.0",
+						"array-unique": "^0.3.2",
+						"extend-shallow": "^2.0.1",
+						"fill-range": "^4.0.0",
+						"isobject": "^3.0.1",
+						"repeat-element": "^1.1.2",
+						"snapdragon": "^0.8.1",
+						"snapdragon-node": "^2.0.1",
+						"split-string": "^3.0.2",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
+					}
+				},
+				"browser-resolve": {
+					"version": "1.11.3",
+					"resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
+					"integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
+					"dev": true,
+					"requires": {
+						"resolve": "1.1.7"
 					}
 				},
 				"bser": {
@@ -5058,7 +6636,7 @@
 					"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 					"dev": true,
 					"requires": {
-						"node-int64": "0.4.0"
+						"node-int64": "^0.4.0"
 					}
 				},
 				"callsites": {
@@ -5074,36 +6652,194 @@
 					"dev": true
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"cliui": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^2.1.1",
+						"strip-ansi": "^4.0.0",
+						"wrap-ansi": "^2.0.0"
+					}
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
+					"dev": true
+				},
+				"cssstyle": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.3.1.tgz",
+					"integrity": "sha512-tNvaxM5blOnxanyxI6panOsnfiyLRj3HV4qjqqS45WPNS1usdYWRUQjqTEEELK73lpeP/1KoIGYUwrBn/VcECA==",
+					"dev": true,
+					"requires": {
+						"cssom": "0.3.x"
+					}
+				},
+				"escodegen": {
+					"version": "1.10.0",
+					"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
+					"integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
+					"dev": true,
+					"requires": {
+						"esprima": "^3.1.3",
+						"estraverse": "^4.2.0",
+						"esutils": "^2.0.2",
+						"optionator": "^0.8.1",
+						"source-map": "~0.6.1"
 					},
 					"dependencies": {
-						"string-width": {
-							"version": "1.0.2",
-							"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-							"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true,
+							"optional": true
+						}
+					}
+				},
+				"esprima": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+					"integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+					"dev": true
+				},
+				"expand-brackets": {
+					"version": "2.1.4",
+					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
+					"dev": true,
+					"requires": {
+						"debug": "^2.3.3",
+						"define-property": "^0.2.5",
+						"extend-shallow": "^2.0.1",
+						"posix-character-classes": "^0.1.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "0.2.5",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"code-point-at": "1.1.0",
-								"is-fullwidth-code-point": "1.0.0",
-								"strip-ansi": "3.0.1"
+								"is-descriptor": "^0.1.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						},
+						"is-accessor-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-data-descriptor": {
+							"version": "0.1.4",
+							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
+							"dev": true,
+							"requires": {
+								"kind-of": "^3.0.2"
+							},
+							"dependencies": {
+								"kind-of": {
+									"version": "3.2.2",
+									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+									"dev": true,
+									"requires": {
+										"is-buffer": "^1.1.5"
+									}
+								}
+							}
+						},
+						"is-descriptor": {
+							"version": "0.1.6",
+							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
+							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+							"dev": true,
+							"requires": {
+								"is-accessor-descriptor": "^0.1.6",
+								"is-data-descriptor": "^0.1.4",
+								"kind-of": "^5.0.0"
+							}
+						},
+						"kind-of": {
+							"version": "5.1.0",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
+							"integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+							"dev": true
+						}
+					}
+				},
+				"extglob": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
+					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
+					"dev": true,
+					"requires": {
+						"array-unique": "^0.3.2",
+						"define-property": "^1.0.0",
+						"expand-brackets": "^2.1.4",
+						"extend-shallow": "^2.0.1",
+						"fragment-cache": "^0.2.1",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.1"
+					},
+					"dependencies": {
+						"define-property": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+							"dev": true,
+							"requires": {
+								"is-descriptor": "^1.0.0"
+							}
+						},
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
 							}
 						}
 					}
@@ -5114,7 +6850,30 @@
 					"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 					"dev": true,
 					"requires": {
-						"bser": "2.0.0"
+						"bser": "^2.0.0"
+					}
+				},
+				"fill-range": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-number": "^3.0.0",
+						"repeat-string": "^1.6.1",
+						"to-regex-range": "^2.1.0"
+					},
+					"dependencies": {
+						"extend-shallow": {
+							"version": "2.0.1",
+							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+							"dev": true,
+							"requires": {
+								"is-extendable": "^0.1.0"
+							}
+						}
 					}
 				},
 				"find-up": {
@@ -5123,7 +6882,7 @@
 					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 					"dev": true,
 					"requires": {
-						"locate-path": "2.0.0"
+						"locate-path": "^2.0.0"
 					}
 				},
 				"glob": {
@@ -5132,182 +6891,317 @@
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"dev": true,
 					"requires": {
-						"fs.realpath": "1.0.0",
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"fs.realpath": "^1.0.0",
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "^3.0.4",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				},
 				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
-				"jest-config": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-21.2.1.tgz",
-					"integrity": "sha512-fJru5HtlD/5l2o25eY9xT0doK3t2dlglrqoGpbktduyoI0T5CwuB++2YfoNZCrgZipTwPuAGonYv0q7+8yDc/A==",
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"glob": "7.1.2",
-						"jest-environment-jsdom": "21.2.1",
-						"jest-environment-node": "21.2.1",
-						"jest-get-type": "21.2.0",
-						"jest-jasmine2": "21.2.1",
-						"jest-regex-util": "21.2.0",
-						"jest-resolve": "21.2.0",
-						"jest-util": "21.2.1",
-						"jest-validate": "21.2.1",
-						"pretty-format": "21.2.1"
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"is-fullwidth-code-point": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					},
+					"dependencies": {
+						"kind-of": {
+							"version": "3.2.2",
+							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+							"dev": true,
+							"requires": {
+								"is-buffer": "^1.1.5"
+							}
+						}
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"istanbul-lib-coverage": {
+					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
+					"integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+					"dev": true
+				},
+				"istanbul-lib-instrument": {
+					"version": "1.10.1",
+					"resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
+					"integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
+					"dev": true,
+					"requires": {
+						"babel-generator": "^6.18.0",
+						"babel-template": "^6.16.0",
+						"babel-traverse": "^6.18.0",
+						"babel-types": "^6.18.0",
+						"babylon": "^6.18.0",
+						"istanbul-lib-coverage": "^1.2.0",
+						"semver": "^5.3.0"
+					}
+				},
+				"jest-config": {
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-config/-/jest-config-23.2.0.tgz",
+					"integrity": "sha1-0vtVb9WioZw561bROdzKXa0qHIg=",
+					"dev": true,
+					"requires": {
+						"babel-core": "^6.0.0",
+						"babel-jest": "^23.2.0",
+						"chalk": "^2.0.1",
+						"glob": "^7.1.1",
+						"jest-environment-jsdom": "^23.2.0",
+						"jest-environment-node": "^23.2.0",
+						"jest-get-type": "^22.1.0",
+						"jest-jasmine2": "^23.2.0",
+						"jest-regex-util": "^23.0.0",
+						"jest-resolve": "^23.2.0",
+						"jest-util": "^23.2.0",
+						"jest-validate": "^23.2.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-diff": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-21.2.1.tgz",
-					"integrity": "sha512-E5fu6r7PvvPr5qAWE1RaUwIh/k6Zx/3OOkZ4rk5dBJkEWRrUuSgbMt2EO8IUTPTd6DOqU3LW6uTIwX5FRvXoFA==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-23.2.0.tgz",
+					"integrity": "sha1-nyz0tR4Sx5FVAgCrwWtHEwrxBio=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"diff": "3.4.0",
-						"jest-get-type": "21.2.0",
-						"pretty-format": "21.2.1"
+						"chalk": "^2.0.1",
+						"diff": "^3.2.0",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-environment-jsdom": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz",
-					"integrity": "sha512-mecaeNh0eWmzNrUNMWARysc0E9R96UPBamNiOCYL28k7mksb1d0q6DD38WKP7ABffjnXyUWJPVaWRgUOivwXwg==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-23.2.0.tgz",
+					"integrity": "sha1-NjRgOgipdbDKimWDIPVqVKjgRVg=",
 					"dev": true,
 					"requires": {
-						"jest-mock": "21.2.0",
-						"jest-util": "21.2.1",
-						"jsdom": "9.12.0"
+						"jest-mock": "^23.2.0",
+						"jest-util": "^23.2.0",
+						"jsdom": "^11.5.1"
 					}
 				},
 				"jest-environment-node": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-21.2.1.tgz",
-					"integrity": "sha512-R211867wx9mVBVHzrjGRGTy5cd05K7eqzQl/WyZixR/VkJ4FayS8qkKXZyYnwZi6Rxo6WEV81cDbiUx/GfuLNw==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-23.2.0.tgz",
+					"integrity": "sha1-tv5BNy44IJO7bz2b32wcTsClDxg=",
 					"dev": true,
 					"requires": {
-						"jest-mock": "21.2.0",
-						"jest-util": "21.2.1"
+						"jest-mock": "^23.2.0",
+						"jest-util": "^23.2.0"
 					}
 				},
 				"jest-haste-map": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-21.2.0.tgz",
-					"integrity": "sha512-5LhsY/loPH7wwOFRMs+PT4aIAORJ2qwgbpMFlbWbxfN0bk3ZCwxJ530vrbSiTstMkYLao6JwBkLhCJ5XbY7ZHw==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-23.2.0.tgz",
+					"integrity": "sha1-0Qy6wAfGlZSMjvGCGisu0tTy1Ng=",
 					"dev": true,
 					"requires": {
-						"fb-watchman": "2.0.0",
-						"graceful-fs": "4.1.11",
-						"jest-docblock": "21.2.0",
-						"micromatch": "2.3.11",
-						"sane": "2.2.0",
-						"worker-farm": "1.5.2"
+						"fb-watchman": "^2.0.0",
+						"graceful-fs": "^4.1.11",
+						"jest-docblock": "^23.2.0",
+						"jest-serializer": "^23.0.1",
+						"jest-worker": "^23.2.0",
+						"micromatch": "^3.1.10",
+						"sane": "^2.0.0"
 					}
 				},
 				"jest-jasmine2": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz",
-					"integrity": "sha512-lw8FXXIEekD+jYNlStfgNsUHpfMWhWWCgHV7n0B7mA/vendH7vBFs8xybjQsDzJSduptBZJHqQX9SMssya9+3A==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-23.2.0.tgz",
+					"integrity": "sha1-qmcM2x5NX47HdMlN2l4QX+M9i7Q=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"expect": "21.2.1",
-						"graceful-fs": "4.1.11",
-						"jest-diff": "21.2.1",
-						"jest-matcher-utils": "21.2.1",
-						"jest-message-util": "21.2.1",
-						"jest-snapshot": "21.2.1",
-						"p-cancelable": "0.3.0"
+						"chalk": "^2.0.1",
+						"co": "^4.6.0",
+						"expect": "^23.2.0",
+						"is-generator-fn": "^1.0.0",
+						"jest-diff": "^23.2.0",
+						"jest-each": "^23.2.0",
+						"jest-matcher-utils": "^23.2.0",
+						"jest-message-util": "^23.2.0",
+						"jest-snapshot": "^23.2.0",
+						"jest-util": "^23.2.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-matcher-utils": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz",
-					"integrity": "sha512-kn56My+sekD43dwQPrXBl9Zn9tAqwoy25xxe7/iY4u+mG8P3ALj5IK7MLHZ4Mi3xW7uWVCjGY8cm4PqgbsqMCg==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz",
+					"integrity": "sha1-TUmB8jIT6Tnjzt8j3DTHR7WuGRM=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"jest-get-type": "21.2.0",
-						"pretty-format": "21.2.1"
+						"chalk": "^2.0.1",
+						"jest-get-type": "^22.1.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-mock": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-21.2.0.tgz",
-					"integrity": "sha512-aZDfyVf0LEoABWiY6N0d+O963dUQSyUa4qgzurHR3TBDPen0YxKCJ6l2i7lQGh1tVdsuvdrCZ4qPj+A7PievCw==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-23.2.0.tgz",
+					"integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=",
 					"dev": true
 				},
 				"jest-resolve": {
-					"version": "21.2.0",
-					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-21.2.0.tgz",
-					"integrity": "sha512-vefQ/Lr+VdNvHUZFQXWtOqHX3HEdOc2MtSahBO89qXywEbUxGPB9ZLP9+BHinkxb60UT2Q/tTDOS6rYc6Mwigw==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-23.2.0.tgz",
+					"integrity": "sha1-oHkK1aO5kAKrTb/L+Nni1qabPZk=",
 					"dev": true,
 					"requires": {
-						"browser-resolve": "1.11.2",
-						"chalk": "2.3.0",
-						"is-builtin-module": "1.0.0"
+						"browser-resolve": "^1.11.3",
+						"chalk": "^2.0.1",
+						"realpath-native": "^1.0.0"
 					}
 				},
 				"jest-runtime": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-21.2.1.tgz",
-					"integrity": "sha512-6omlpA3+NSE+rHwD0PQjNEjZeb2z+oRmuehMfM1tWQVum+E0WV3pFt26Am0DUfQkkPyTABvxITRjCUclYgSOsA==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-23.2.0.tgz",
+					"integrity": "sha1-YtywF2ahxMZGltwJAgnnbOGq3Lw=",
 					"dev": true,
 					"requires": {
-						"babel-core": "6.26.0",
-						"babel-jest": "21.2.0",
-						"babel-plugin-istanbul": "4.1.5",
-						"chalk": "2.3.0",
-						"convert-source-map": "1.5.0",
-						"graceful-fs": "4.1.11",
-						"jest-config": "21.2.1",
-						"jest-haste-map": "21.2.0",
-						"jest-regex-util": "21.2.0",
-						"jest-resolve": "21.2.0",
-						"jest-util": "21.2.1",
-						"json-stable-stringify": "1.0.1",
-						"micromatch": "2.3.11",
-						"slash": "1.0.0",
+						"babel-core": "^6.0.0",
+						"babel-plugin-istanbul": "^4.1.6",
+						"chalk": "^2.0.1",
+						"convert-source-map": "^1.4.0",
+						"exit": "^0.1.2",
+						"fast-json-stable-stringify": "^2.0.0",
+						"graceful-fs": "^4.1.11",
+						"jest-config": "^23.2.0",
+						"jest-haste-map": "^23.2.0",
+						"jest-message-util": "^23.2.0",
+						"jest-regex-util": "^23.0.0",
+						"jest-resolve": "^23.2.0",
+						"jest-snapshot": "^23.2.0",
+						"jest-util": "^23.2.0",
+						"jest-validate": "^23.2.0",
+						"micromatch": "^3.1.10",
+						"realpath-native": "^1.0.0",
+						"slash": "^1.0.0",
 						"strip-bom": "3.0.0",
-						"write-file-atomic": "2.3.0",
-						"yargs": "9.0.1"
+						"write-file-atomic": "^2.1.0",
+						"yargs": "^11.0.0"
 					}
 				},
 				"jest-snapshot": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-21.2.1.tgz",
-					"integrity": "sha512-bpaeBnDpdqaRTzN8tWg0DqOTo2DvD3StOemxn67CUd1p1Po+BUpvePAp44jdJ7Pxcjfg+42o4NHw1SxdCA2rvg==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.2.0.tgz",
+					"integrity": "sha1-x6PQFxd7utYMillYac+QqHguan4=",
 					"dev": true,
 					"requires": {
-						"chalk": "2.3.0",
-						"jest-diff": "21.2.1",
-						"jest-matcher-utils": "21.2.1",
-						"mkdirp": "0.5.1",
-						"natural-compare": "1.4.0",
-						"pretty-format": "21.2.1"
+						"chalk": "^2.0.1",
+						"jest-diff": "^23.2.0",
+						"jest-matcher-utils": "^23.2.0",
+						"mkdirp": "^0.5.1",
+						"natural-compare": "^1.4.0",
+						"pretty-format": "^23.2.0"
 					}
 				},
 				"jest-util": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz",
-					"integrity": "sha512-r20W91rmHY3fnCoO7aOAlyfC51x2yeV3xF+prGsJAUsYhKeV670ZB8NO88Lwm7ASu8SdH0S+U+eFf498kjhA4g==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-23.2.0.tgz",
+					"integrity": "sha1-YrdwdXaW2W4JSgS48cNzylClqy4=",
 					"dev": true,
 					"requires": {
-						"callsites": "2.0.0",
-						"chalk": "2.3.0",
-						"graceful-fs": "4.1.11",
-						"jest-message-util": "21.2.1",
-						"jest-mock": "21.2.0",
-						"jest-validate": "21.2.1",
-						"mkdirp": "0.5.1"
+						"callsites": "^2.0.0",
+						"chalk": "^2.0.1",
+						"graceful-fs": "^4.1.11",
+						"is-ci": "^1.0.10",
+						"jest-message-util": "^23.2.0",
+						"mkdirp": "^0.5.1",
+						"slash": "^1.0.0",
+						"source-map": "^0.6.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true
+						}
+					}
+				},
+				"jsdom": {
+					"version": "11.11.0",
+					"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-11.11.0.tgz",
+					"integrity": "sha512-ou1VyfjwsSuWkudGxb03FotDajxAto6USAlmMZjE2lc0jCznt7sBWkhfRBRaWwbnmDqdMSTKTLT5d9sBFkkM7A==",
+					"dev": true,
+					"requires": {
+						"abab": "^1.0.4",
+						"acorn": "^5.3.0",
+						"acorn-globals": "^4.1.0",
+						"array-equal": "^1.0.0",
+						"cssom": ">= 0.3.2 < 0.4.0",
+						"cssstyle": ">= 0.3.1 < 0.4.0",
+						"data-urls": "^1.0.0",
+						"domexception": "^1.0.0",
+						"escodegen": "^1.9.0",
+						"html-encoding-sniffer": "^1.0.2",
+						"left-pad": "^1.2.0",
+						"nwsapi": "^2.0.0",
+						"parse5": "4.0.0",
+						"pn": "^1.1.0",
+						"request": "^2.83.0",
+						"request-promise-native": "^1.0.5",
+						"sax": "^1.2.4",
+						"symbol-tree": "^3.2.2",
+						"tough-cookie": "^2.3.3",
+						"w3c-hr-time": "^1.0.1",
+						"webidl-conversions": "^4.0.2",
+						"whatwg-encoding": "^1.0.3",
+						"whatwg-mimetype": "^2.1.0",
+						"whatwg-url": "^6.4.1",
+						"ws": "^4.0.0",
+						"xml-name-validator": "^3.0.0"
 					}
 				},
 				"json5": {
@@ -5316,24 +7210,31 @@
 					"integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
 					"dev": true
 				},
-				"load-json-file": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-					"integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				},
+				"micromatch": {
+					"version": "3.1.10",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"parse-json": "2.2.0",
-						"pify": "2.3.0",
-						"strip-bom": "3.0.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
-						}
+						"arr-diff": "^4.0.0",
+						"array-unique": "^0.3.2",
+						"braces": "^2.3.1",
+						"define-property": "^2.0.2",
+						"extend-shallow": "^3.0.2",
+						"extglob": "^2.0.4",
+						"fragment-cache": "^0.2.1",
+						"kind-of": "^6.0.2",
+						"nanomatch": "^1.2.9",
+						"object.pick": "^1.3.0",
+						"regex-not": "^1.0.0",
+						"snapdragon": "^0.8.1",
+						"to-regex": "^3.0.2"
 					}
 				},
 				"minimatch": {
@@ -5342,7 +7243,7 @@
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"os-locale": {
@@ -5351,69 +7252,72 @@
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "0.7.0",
-						"lcid": "1.0.0",
-						"mem": "1.1.0"
+						"execa": "^0.7.0",
+						"lcid": "^1.0.0",
+						"mem": "^1.1.0"
 					}
 				},
-				"path-type": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-					"integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-					"dev": true,
-					"requires": {
-						"pify": "2.3.0"
-					},
-					"dependencies": {
-						"pify": {
-							"version": "2.3.0",
-							"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-							"integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-							"dev": true
-						}
-					}
-				},
-				"pify": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+				"parse5": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-4.0.0.tgz",
+					"integrity": "sha512-VrZ7eOd3T1Fk4XWNXMgiGBK/z0MG48BWG2uQNU4I72fkQuKUTZpl+u9k+CxEG0twMVzSmXEEz12z5Fnw1jIQFA==",
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-					"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0",
-						"ansi-styles": "3.2.0"
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
 					}
 				},
-				"read-pkg": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-					"integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-					"dev": true,
-					"requires": {
-						"load-json-file": "2.0.0",
-						"normalize-package-data": "2.4.0",
-						"path-type": "2.0.0"
-					}
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+					"dev": true
+				},
+				"resolve": {
+					"version": "1.1.7",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+					"integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+					"dev": true
 				},
 				"sane": {
-					"version": "2.2.0",
-					"resolved": "https://registry.npmjs.org/sane/-/sane-2.2.0.tgz",
-					"integrity": "sha512-OSJxhHO0CgPUw3lUm3GhfREAfza45smvEI9ozuFrxKG10GHVo0ryW9FK5VYlLvxj0SV7HVKHW0voYJIRu27GWg==",
+					"version": "2.5.2",
+					"resolved": "https://registry.npmjs.org/sane/-/sane-2.5.2.tgz",
+					"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 					"dev": true,
 					"requires": {
-						"anymatch": "1.3.2",
-						"exec-sh": "0.2.1",
-						"fb-watchman": "2.0.0",
-						"fsevents": "1.1.3",
-						"minimatch": "3.0.4",
-						"minimist": "1.2.0",
-						"walker": "1.0.7",
-						"watch": "0.18.0"
+						"anymatch": "^2.0.0",
+						"capture-exit": "^1.2.0",
+						"exec-sh": "^0.2.0",
+						"fb-watchman": "^2.0.0",
+						"fsevents": "^1.2.3",
+						"micromatch": "^3.1.4",
+						"minimist": "^1.1.1",
+						"walker": "~1.0.5",
+						"watch": "~0.18.0"
+					}
+				},
+				"source-map-support": {
+					"version": "0.5.6",
+					"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
+					"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+					"dev": true,
+					"requires": {
+						"buffer-from": "^1.0.0",
+						"source-map": "^0.6.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.6.1",
+							"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+							"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+							"dev": true
+						}
 					}
 				},
 				"string-width": {
@@ -5422,25 +7326,17 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
-					},
-					"dependencies": {
-						"is-fullwidth-code-point": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-							"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-							"dev": true
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-							"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-							"dev": true,
-							"requires": {
-								"ansi-regex": "3.0.0"
-							}
-						}
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
+					}
+				},
+				"strip-ansi": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+					"dev": true,
+					"requires": {
+						"ansi-regex": "^3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -5450,25 +7346,25 @@
 					"dev": true
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^3.0.0"
 					}
 				},
 				"test-exclude": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.1.1.tgz",
-					"integrity": "sha512-35+Asrsk3XHJDBgf/VRFexPgh3UyETv8IAn/LRTiZjVy6rjPVqdEk8dJcJYBzl1w0XCJM48lvTy8SfEsCWS4nA==",
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
+					"integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
 					"dev": true,
 					"requires": {
-						"arrify": "1.0.1",
-						"micromatch": "2.3.11",
-						"object-assign": "4.1.1",
-						"read-pkg-up": "1.0.1",
-						"require-main-filename": "1.0.1"
+						"arrify": "^1.0.1",
+						"micromatch": "^3.1.8",
+						"object-assign": "^4.1.0",
+						"read-pkg-up": "^1.0.1",
+						"require-main-filename": "^1.0.1"
 					}
 				},
 				"throat": {
@@ -5477,14 +7373,34 @@
 					"integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
 					"dev": true
 				},
+				"tr46": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+					"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
+					"dev": true,
+					"requires": {
+						"punycode": "^2.1.0"
+					}
+				},
 				"watch": {
 					"version": "0.18.0",
 					"resolved": "https://registry.npmjs.org/watch/-/watch-0.18.0.tgz",
 					"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 					"dev": true,
 					"requires": {
-						"exec-sh": "0.2.1",
-						"minimist": "1.2.0"
+						"exec-sh": "^0.2.0",
+						"minimist": "^1.2.0"
+					}
+				},
+				"whatwg-url": {
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+					"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+					"dev": true,
+					"requires": {
+						"lodash.sortby": "^4.7.0",
+						"tr46": "^1.0.1",
+						"webidl-conversions": "^4.0.2"
 					}
 				},
 				"which-module": {
@@ -5499,51 +7415,44 @@
 					"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "4.1.11",
-						"imurmurhash": "0.1.4",
-						"signal-exit": "3.0.2"
+						"graceful-fs": "^4.1.11",
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.2"
 					}
 				},
+				"xml-name-validator": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+					"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+					"dev": true
+				},
 				"yargs": {
-					"version": "9.0.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-9.0.1.tgz",
-					"integrity": "sha1-UqzCP+7Kw0BCB47njAwAf1CF20w=",
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+					"integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "2.1.0",
-						"read-pkg-up": "2.0.0",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "2.1.1",
-						"which-module": "2.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "7.0.0"
-					},
-					"dependencies": {
-						"read-pkg-up": {
-							"version": "2.0.0",
-							"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-							"integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-							"dev": true,
-							"requires": {
-								"find-up": "2.1.0",
-								"read-pkg": "2.0.0"
-							}
-						}
+						"cliui": "^4.0.0",
+						"decamelize": "^1.1.1",
+						"find-up": "^2.1.0",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^2.0.0",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^2.0.0",
+						"which-module": "^2.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^9.0.2"
 					}
 				},
 				"yargs-parser": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-					"integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+					"version": "9.0.2",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+					"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 					"dev": true,
 					"requires": {
-						"camelcase": "4.1.0"
+						"camelcase": "^4.1.0"
 					}
 				}
 			}
@@ -5553,47 +7462,47 @@
 			"resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-17.0.3.tgz",
 			"integrity": "sha1-7/QFX+jD4XyV7Rqq9fcZxCC4ax8=",
 			"requires": {
-				"babel-core": "6.26.0",
-				"babel-jest": "17.0.2",
-				"babel-plugin-istanbul": "2.0.3",
-				"chalk": "1.1.3",
-				"graceful-fs": "4.1.11",
-				"jest-config": "17.0.3",
-				"jest-file-exists": "17.0.0",
-				"jest-haste-map": "17.0.3",
-				"jest-mock": "17.0.2",
-				"jest-resolve": "17.0.3",
-				"jest-snapshot": "17.0.3",
-				"jest-util": "17.0.2",
-				"json-stable-stringify": "1.0.1",
-				"multimatch": "2.1.0",
-				"yargs": "6.6.0"
+				"babel-core": "^6.0.0",
+				"babel-jest": "^17.0.2",
+				"babel-plugin-istanbul": "^2.0.0",
+				"chalk": "^1.1.3",
+				"graceful-fs": "^4.1.6",
+				"jest-config": "^17.0.3",
+				"jest-file-exists": "^17.0.0",
+				"jest-haste-map": "^17.0.3",
+				"jest-mock": "^17.0.2",
+				"jest-resolve": "^17.0.3",
+				"jest-snapshot": "^17.0.3",
+				"jest-util": "^17.0.2",
+				"json-stable-stringify": "^1.0.0",
+				"multimatch": "^2.1.0",
+				"yargs": "^6.3.0"
 			},
 			"dependencies": {
 				"babel-core": {
-					"version": "6.26.0",
-					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
-					"integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+					"version": "6.26.3",
+					"resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
+					"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 					"requires": {
-						"babel-code-frame": "6.26.0",
-						"babel-generator": "6.26.0",
-						"babel-helpers": "6.24.1",
-						"babel-messages": "6.23.0",
-						"babel-register": "6.26.0",
-						"babel-runtime": "6.26.0",
-						"babel-template": "6.26.0",
-						"babel-traverse": "6.26.0",
-						"babel-types": "6.26.0",
-						"babylon": "6.18.0",
-						"convert-source-map": "1.5.0",
-						"debug": "2.6.9",
-						"json5": "0.5.1",
-						"lodash": "4.17.4",
-						"minimatch": "3.0.4",
-						"path-is-absolute": "1.0.1",
-						"private": "0.1.8",
-						"slash": "1.0.0",
-						"source-map": "0.5.7"
+						"babel-code-frame": "^6.26.0",
+						"babel-generator": "^6.26.0",
+						"babel-helpers": "^6.24.1",
+						"babel-messages": "^6.23.0",
+						"babel-register": "^6.26.0",
+						"babel-runtime": "^6.26.0",
+						"babel-template": "^6.26.0",
+						"babel-traverse": "^6.26.0",
+						"babel-types": "^6.26.0",
+						"babylon": "^6.18.0",
+						"convert-source-map": "^1.5.1",
+						"debug": "^2.6.9",
+						"json5": "^0.5.1",
+						"lodash": "^4.17.4",
+						"minimatch": "^3.0.4",
+						"path-is-absolute": "^1.0.1",
+						"private": "^0.1.8",
+						"slash": "^1.0.0",
+						"source-map": "^0.5.7"
 					}
 				},
 				"babel-jest": {
@@ -5601,9 +7510,9 @@
 					"resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-17.0.2.tgz",
 					"integrity": "sha1-jVHg0DdZcTwzHxCOsLLqpMbv/3Q=",
 					"requires": {
-						"babel-core": "6.26.0",
-						"babel-plugin-istanbul": "2.0.3",
-						"babel-preset-jest": "17.0.2"
+						"babel-core": "^6.0.0",
+						"babel-plugin-istanbul": "^2.0.0",
+						"babel-preset-jest": "^17.0.2"
 					}
 				},
 				"babel-plugin-jest-hoist": {
@@ -5616,7 +7525,7 @@
 					"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-17.0.2.tgz",
 					"integrity": "sha1-FB6TXevhZKqgNkwiDTHMshdkk7I=",
 					"requires": {
-						"babel-plugin-jest-hoist": "17.0.2"
+						"babel-plugin-jest-hoist": "^17.0.2"
 					}
 				},
 				"camelcase": {
@@ -5629,10 +7538,15 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
+				},
+				"convert-source-map": {
+					"version": "1.5.1",
+					"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+					"integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
 				},
 				"json5": {
 					"version": "0.5.1",
@@ -5644,7 +7558,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				},
 				"yargs": {
@@ -5652,34 +7566,40 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^4.2.0"
 					}
 				}
 			}
+		},
+		"jest-serializer": {
+			"version": "23.0.1",
+			"resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-23.0.1.tgz",
+			"integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
+			"dev": true
 		},
 		"jest-snapshot": {
 			"version": "17.0.3",
 			"resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-17.0.3.tgz",
 			"integrity": "sha1-yBmdtMy9VRXP7MjoAKsHa92nq8A=",
 			"requires": {
-				"jest-diff": "17.0.3",
-				"jest-file-exists": "17.0.0",
-				"jest-matcher-utils": "17.0.3",
-				"jest-util": "17.0.2",
-				"natural-compare": "1.4.0",
-				"pretty-format": "4.2.3"
+				"jest-diff": "^17.0.3",
+				"jest-file-exists": "^17.0.0",
+				"jest-matcher-utils": "^17.0.3",
+				"jest-util": "^17.0.2",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "~4.2.1"
 			}
 		},
 		"jest-util": {
@@ -5687,24 +7607,24 @@
 			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-17.0.2.tgz",
 			"integrity": "sha1-n9nagJHpkE+5dtp+TYkSyiaWhjg=",
 			"requires": {
-				"chalk": "1.1.3",
-				"diff": "3.4.0",
-				"graceful-fs": "4.1.11",
-				"jest-file-exists": "17.0.0",
-				"jest-mock": "17.0.2",
-				"mkdirp": "0.5.1"
+				"chalk": "^1.1.1",
+				"diff": "^3.0.0",
+				"graceful-fs": "^4.1.6",
+				"jest-file-exists": "^17.0.0",
+				"jest-mock": "^17.0.2",
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"jest-validate": {
-			"version": "21.2.1",
-			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
-			"integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.2.0.tgz",
+			"integrity": "sha1-Z8i5CeEa8XAXZSOIlMZ6wykbGV4=",
 			"dev": true,
 			"requires": {
-				"chalk": "2.3.0",
-				"jest-get-type": "21.2.0",
-				"leven": "2.1.0",
-				"pretty-format": "21.2.1"
+				"chalk": "^2.0.1",
+				"jest-get-type": "^22.1.0",
+				"leven": "^2.1.0",
+				"pretty-format": "^23.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -5714,29 +7634,29 @@
 					"dev": true
 				},
 				"ansi-styles": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-					"integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "1.9.1"
+						"color-convert": "^1.9.0"
 					}
 				},
 				"chalk": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-					"integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "3.2.0",
-						"escape-string-regexp": "1.0.5",
-						"supports-color": "4.5.0"
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
 					}
 				},
 				"has-flag": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-					"integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
 					"dev": true
 				},
 				"leven": {
@@ -5746,24 +7666,87 @@
 					"dev": true
 				},
 				"pretty-format": {
-					"version": "21.2.1",
-					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
-					"integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+					"version": "23.2.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+					"integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0",
-						"ansi-styles": "3.2.0"
+						"ansi-regex": "^3.0.0",
+						"ansi-styles": "^3.2.0"
 					}
 				},
 				"supports-color": {
-					"version": "4.5.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-					"integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 					"dev": true,
 					"requires": {
-						"has-flag": "2.0.0"
+						"has-flag": "^3.0.0"
 					}
 				}
+			}
+		},
+		"jest-watcher": {
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-23.2.0.tgz",
+			"integrity": "sha1-Z46FKJbpGenZoOtLi68a4nliDqk=",
+			"dev": true,
+			"requires": {
+				"ansi-escapes": "^3.0.0",
+				"chalk": "^2.0.1",
+				"string-length": "^2.0.0"
+			},
+			"dependencies": {
+				"ansi-escapes": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+					"integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.1",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+					"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.4.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+					"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"jest-worker": {
+			"version": "23.2.0",
+			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-23.2.0.tgz",
+			"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
+			"dev": true,
+			"requires": {
+				"merge-stream": "^1.0.1"
 			}
 		},
 		"js-tokens": {
@@ -5776,8 +7759,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
 			"integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
 			"requires": {
-				"argparse": "1.0.9",
-				"esprima": "4.0.0"
+				"argparse": "^1.0.7",
+				"esprima": "^4.0.0"
 			},
 			"dependencies": {
 				"esprima": {
@@ -5794,26 +7777,48 @@
 			"optional": true
 		},
 		"jscodeshift": {
-			"version": "0.3.32",
-			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.3.32.tgz",
-			"integrity": "sha1-3s5etgLxY0DY2VTH+WrJB8UC6rs=",
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.5.1.tgz",
+			"integrity": "sha512-sRMollbhbmSDrR79JMAnhEjyZJlQQVozeeY9A6/KNuV26DNcuB3mGSCWXp0hks9dcwRNOELbNOiwraZaXXRk5Q==",
 			"requires": {
-				"async": "1.5.2",
-				"babel-core": "5.8.38",
-				"babel-plugin-transform-flow-strip-types": "6.22.0",
-				"babel-preset-es2015": "6.24.1",
-				"babel-preset-stage-1": "6.24.1",
-				"babel-register": "6.26.0",
-				"babylon": "6.18.0",
-				"colors": "1.1.2",
-				"flow-parser": "0.59.0",
-				"lodash": "4.17.4",
-				"micromatch": "2.3.11",
+				"babel-plugin-transform-flow-strip-types": "^6.8.0",
+				"babel-preset-es2015": "^6.9.0",
+				"babel-preset-stage-1": "^6.5.0",
+				"babel-register": "^6.9.0",
+				"babylon": "^7.0.0-beta.47",
+				"colors": "^1.1.2",
+				"flow-parser": "^0.*",
+				"lodash": "^4.13.1",
+				"micromatch": "^2.3.7",
+				"neo-async": "^2.5.0",
 				"node-dir": "0.1.8",
-				"nomnom": "1.8.1",
-				"recast": "0.12.9",
-				"temp": "0.8.3",
-				"write-file-atomic": "1.3.4"
+				"nomnom": "^1.8.1",
+				"recast": "^0.15.0",
+				"temp": "^0.8.1",
+				"write-file-atomic": "^1.2.0"
+			},
+			"dependencies": {
+				"babylon": {
+					"version": "7.0.0-beta.47",
+					"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
+					"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ=="
+				},
+				"recast": {
+					"version": "0.15.0",
+					"resolved": "https://registry.npmjs.org/recast/-/recast-0.15.0.tgz",
+					"integrity": "sha512-47C2mIxQYvFICrTNuV4+xGgBa1nAoq42ANN5oDTSBIJ50NX7jcki7gAC6HWYptnQgHmqIRTHJq8OKdi3fwgyNQ==",
+					"requires": {
+						"ast-types": "0.11.5",
+						"esprima": "~4.0.0",
+						"private": "~0.1.5",
+						"source-map": "~0.6.1"
+					}
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				}
 			}
 		},
 		"jsdom": {
@@ -5821,25 +7826,25 @@
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
 			"integrity": "sha1-6MVG//ywbADUgzyoRBD+1/igl9Q=",
 			"requires": {
-				"abab": "1.0.4",
-				"acorn": "4.0.13",
-				"acorn-globals": "3.1.0",
-				"array-equal": "1.0.0",
-				"content-type-parser": "1.0.2",
-				"cssom": "0.3.2",
-				"cssstyle": "0.2.37",
-				"escodegen": "1.8.1",
-				"html-encoding-sniffer": "1.0.2",
-				"nwmatcher": "1.4.3",
-				"parse5": "1.5.1",
-				"request": "2.83.0",
-				"sax": "1.2.4",
-				"symbol-tree": "3.2.2",
-				"tough-cookie": "2.3.3",
-				"webidl-conversions": "4.0.2",
-				"whatwg-encoding": "1.0.3",
-				"whatwg-url": "4.8.0",
-				"xml-name-validator": "2.0.1"
+				"abab": "^1.0.3",
+				"acorn": "^4.0.4",
+				"acorn-globals": "^3.1.0",
+				"array-equal": "^1.0.0",
+				"content-type-parser": "^1.0.1",
+				"cssom": ">= 0.3.2 < 0.4.0",
+				"cssstyle": ">= 0.2.37 < 0.3.0",
+				"escodegen": "^1.6.1",
+				"html-encoding-sniffer": "^1.0.1",
+				"nwmatcher": ">= 1.3.9 < 2.0.0",
+				"parse5": "^1.5.1",
+				"request": "^2.79.0",
+				"sax": "^1.2.1",
+				"symbol-tree": "^3.2.1",
+				"tough-cookie": "^2.3.2",
+				"webidl-conversions": "^4.0.0",
+				"whatwg-encoding": "^1.0.1",
+				"whatwg-url": "^4.3.0",
+				"xml-name-validator": "^2.0.1"
 			}
 		},
 		"jsesc": {
@@ -5862,7 +7867,7 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"requires": {
-				"jsonify": "0.0.0"
+				"jsonify": "~0.0.0"
 			}
 		},
 		"json-stringify-safe": {
@@ -5901,7 +7906,7 @@
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"requires": {
-				"is-buffer": "1.1.6"
+				"is-buffer": "^1.1.5"
 			}
 		},
 		"lazy-cache": {
@@ -5914,8 +7919,14 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "1.0.0"
+				"invert-kv": "^1.0.0"
 			}
+		},
+		"left-pad": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
+			"integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
+			"dev": true
 		},
 		"leven": {
 			"version": "1.0.2",
@@ -5927,8 +7938,8 @@
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"requires": {
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2"
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
 			}
 		},
 		"load-json-file": {
@@ -5936,11 +7947,11 @@
 			"resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"locate-path": {
@@ -5949,8 +7960,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "2.0.0",
-				"path-exists": "3.0.0"
+				"p-locate": "^2.0.0",
+				"path-exists": "^3.0.0"
 			},
 			"dependencies": {
 				"path-exists": {
@@ -5962,9 +7973,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.4",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-			"integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+			"version": "4.17.10",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+			"integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
 		},
 		"lodash._arraycopy": {
 			"version": "3.0.0",
@@ -5981,8 +7992,8 @@
 			"resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
 			"integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
 			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash.keys": "3.1.2"
+				"lodash._basecopy": "^3.0.0",
+				"lodash.keys": "^3.0.0"
 			}
 		},
 		"lodash._baseclone": {
@@ -5990,12 +8001,12 @@
 			"resolved": "https://registry.npmjs.org/lodash._baseclone/-/lodash._baseclone-3.3.0.tgz",
 			"integrity": "sha1-MDUZv2OT/n5C802LYw73eU41Qrc=",
 			"requires": {
-				"lodash._arraycopy": "3.0.0",
-				"lodash._arrayeach": "3.0.0",
-				"lodash._baseassign": "3.2.0",
-				"lodash._basefor": "3.0.3",
-				"lodash.isarray": "3.0.4",
-				"lodash.keys": "3.1.2"
+				"lodash._arraycopy": "^3.0.0",
+				"lodash._arrayeach": "^3.0.0",
+				"lodash._baseassign": "^3.0.0",
+				"lodash._basefor": "^3.0.0",
+				"lodash.isarray": "^3.0.0",
+				"lodash.keys": "^3.0.0"
 			}
 		},
 		"lodash._basecopy": {
@@ -6063,8 +8074,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-3.0.2.tgz",
 			"integrity": "sha1-oKHkDYKl6on/WxR7hETtY9koJ9s=",
 			"requires": {
-				"lodash._baseclone": "3.3.0",
-				"lodash._bindcallback": "3.0.1"
+				"lodash._baseclone": "^3.0.0",
+				"lodash._bindcallback": "^3.0.0"
 			}
 		},
 		"lodash.escape": {
@@ -6072,7 +8083,7 @@
 			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
 			"integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
 			"requires": {
-				"lodash._root": "3.0.1"
+				"lodash._root": "^3.0.0"
 			}
 		},
 		"lodash.isarguments": {
@@ -6090,9 +8101,9 @@
 			"resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
 			"integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
 			"requires": {
-				"lodash._getnative": "3.9.1",
-				"lodash.isarguments": "3.1.0",
-				"lodash.isarray": "3.0.4"
+				"lodash._getnative": "^3.0.0",
+				"lodash.isarguments": "^3.0.0",
+				"lodash.isarray": "^3.0.0"
 			}
 		},
 		"lodash.pickby": {
@@ -6105,20 +8116,26 @@
 			"resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
 			"integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
 		},
+		"lodash.sortby": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+			"integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
+			"dev": true
+		},
 		"lodash.template": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
 			"integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
 			"requires": {
-				"lodash._basecopy": "3.0.1",
-				"lodash._basetostring": "3.0.1",
-				"lodash._basevalues": "3.0.0",
-				"lodash._isiterateecall": "3.0.9",
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.escape": "3.2.0",
-				"lodash.keys": "3.1.2",
-				"lodash.restparam": "3.6.1",
-				"lodash.templatesettings": "3.1.1"
+				"lodash._basecopy": "^3.0.0",
+				"lodash._basetostring": "^3.0.0",
+				"lodash._basevalues": "^3.0.0",
+				"lodash._isiterateecall": "^3.0.0",
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.escape": "^3.0.0",
+				"lodash.keys": "^3.0.0",
+				"lodash.restparam": "^3.0.0",
+				"lodash.templatesettings": "^3.0.0"
 			}
 		},
 		"lodash.templatesettings": {
@@ -6126,8 +8143,8 @@
 			"resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
 			"integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
 			"requires": {
-				"lodash._reinterpolate": "3.0.0",
-				"lodash.escape": "3.2.0"
+				"lodash._reinterpolate": "^3.0.0",
+				"lodash.escape": "^3.0.0"
 			}
 		},
 		"lodash.toarray": {
@@ -6145,7 +8162,7 @@
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
 			"integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
 			"requires": {
-				"js-tokens": "3.0.2"
+				"js-tokens": "^3.0.0"
 			},
 			"dependencies": {
 				"js-tokens": {
@@ -6160,8 +8177,8 @@
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
 			"integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
 			"requires": {
-				"pseudomap": "1.0.2",
-				"yallist": "2.1.2"
+				"pseudomap": "^1.0.2",
+				"yallist": "^2.1.2"
 			}
 		},
 		"makeerror": {
@@ -6169,24 +8186,39 @@
 			"resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"requires": {
-				"tmpl": "1.0.4"
+				"tmpl": "1.0.x"
+			}
+		},
+		"map-cache": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
+			"integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
+			"dev": true
+		},
+		"map-visit": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
+			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
+			"dev": true,
+			"requires": {
+				"object-visit": "^1.0.0"
 			}
 		},
 		"marked": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-			"integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+			"version": "0.3.19",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+			"integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
 		},
 		"marked-terminal": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-1.7.0.tgz",
-			"integrity": "sha1-yMRgiBx3LHYEtkNnAH7l938SWQQ=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-2.0.0.tgz",
+			"integrity": "sha1-Xq9Wi+ZvaGVBr6UqVYKAMQox3i0=",
 			"requires": {
-				"cardinal": "1.0.0",
-				"chalk": "1.1.3",
-				"cli-table": "0.3.1",
-				"lodash.assign": "4.2.0",
-				"node-emoji": "1.8.1"
+				"cardinal": "^1.0.0",
+				"chalk": "^1.1.3",
+				"cli-table": "^0.3.1",
+				"lodash.assign": "^4.2.0",
+				"node-emoji": "^1.4.1"
 			}
 		},
 		"mem": {
@@ -6195,7 +8227,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "1.1.0"
+				"mimic-fn": "^1.0.0"
 			}
 		},
 		"merge": {
@@ -6203,24 +8235,33 @@
 			"resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
 			"integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo="
 		},
+		"merge-stream": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
+			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^2.0.1"
+			}
+		},
 		"micromatch": {
 			"version": "2.3.11",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"requires": {
-				"arr-diff": "2.0.0",
-				"array-unique": "0.2.1",
-				"braces": "1.8.5",
-				"expand-brackets": "0.1.5",
-				"extglob": "0.3.2",
-				"filename-regex": "2.0.1",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1",
-				"kind-of": "3.2.2",
-				"normalize-path": "2.1.1",
-				"object.omit": "2.0.1",
-				"parse-glob": "3.0.4",
-				"regex-cache": "0.4.4"
+				"arr-diff": "^2.0.0",
+				"array-unique": "^0.2.1",
+				"braces": "^1.8.2",
+				"expand-brackets": "^0.1.4",
+				"extglob": "^0.3.1",
+				"filename-regex": "^2.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.1",
+				"kind-of": "^3.0.2",
+				"normalize-path": "^2.0.1",
+				"object.omit": "^2.0.0",
+				"parse-glob": "^3.0.4",
+				"regex-cache": "^0.4.2"
 			}
 		},
 		"mime-db": {
@@ -6233,13 +8274,13 @@
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
 			"integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
 			"requires": {
-				"mime-db": "1.30.0"
+				"mime-db": "~1.30.0"
 			}
 		},
 		"mimic-fn": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-			"integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+			"integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
 			"dev": true
 		},
 		"minimatch": {
@@ -6247,13 +8288,34 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
 			"integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
 			"requires": {
-				"brace-expansion": "1.1.8"
+				"brace-expansion": "^1.0.0"
 			}
 		},
 		"minimist": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+		},
+		"mixin-deep": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
+			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+			"dev": true,
+			"requires": {
+				"for-in": "^1.0.2",
+				"is-extendable": "^1.0.1"
+			},
+			"dependencies": {
+				"is-extendable": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+					"dev": true,
+					"requires": {
+						"is-plain-object": "^2.0.4"
+					}
+				}
+			}
 		},
 		"mkdirp": {
 			"version": "0.5.1",
@@ -6280,10 +8342,10 @@
 			"resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"requires": {
-				"array-differ": "1.0.0",
-				"array-union": "1.0.2",
-				"arrify": "1.0.1",
-				"minimatch": "3.0.4"
+				"array-differ": "^1.0.0",
+				"array-union": "^1.0.1",
+				"arrify": "^1.0.0",
+				"minimatch": "^3.0.0"
 			},
 			"dependencies": {
 				"minimatch": {
@@ -6291,7 +8353,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				}
 			}
@@ -6310,16 +8372,65 @@
 			"integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA="
 		},
 		"nan": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-			"integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+			"integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
 			"dev": true,
 			"optional": true
+		},
+		"nanomatch": {
+			"version": "1.2.13",
+			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+			"dev": true,
+			"requires": {
+				"arr-diff": "^4.0.0",
+				"array-unique": "^0.3.2",
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"fragment-cache": "^0.2.1",
+				"is-windows": "^1.0.2",
+				"kind-of": "^6.0.2",
+				"object.pick": "^1.3.0",
+				"regex-not": "^1.0.0",
+				"snapdragon": "^0.8.1",
+				"to-regex": "^3.0.1"
+			},
+			"dependencies": {
+				"arr-diff": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+					"integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
+					"dev": true
+				},
+				"array-unique": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+					"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
 		},
 		"natural-compare": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+		},
+		"neo-async": {
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
+			"integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA=="
+		},
+		"next-tick": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+			"integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
 		},
 		"node-dir": {
 			"version": "0.1.8",
@@ -6331,7 +8442,7 @@
 			"resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
 			"integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
 			"requires": {
-				"lodash.toarray": "4.4.0"
+				"lodash.toarray": "^4.4.0"
 			}
 		},
 		"node-int64": {
@@ -6344,13 +8455,13 @@
 			"resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-4.6.1.tgz",
 			"integrity": "sha1-BW0UJE89zBzq3+aK+c/wxUc6M/M=",
 			"requires": {
-				"cli-usage": "0.1.4",
-				"growly": "1.3.0",
-				"lodash.clonedeep": "3.0.2",
-				"minimist": "1.2.0",
-				"semver": "5.4.1",
-				"shellwords": "0.1.1",
-				"which": "1.3.0"
+				"cli-usage": "^0.1.1",
+				"growly": "^1.2.0",
+				"lodash.clonedeep": "^3.0.0",
+				"minimist": "^1.1.1",
+				"semver": "^5.1.0",
+				"shellwords": "^0.1.0",
+				"which": "^1.0.5"
 			}
 		},
 		"nomnom": {
@@ -6358,8 +8469,8 @@
 			"resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
 			"integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
 			"requires": {
-				"chalk": "0.4.0",
-				"underscore": "1.6.0"
+				"chalk": "~0.4.0",
+				"underscore": "~1.6.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -6372,9 +8483,9 @@
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
 					"integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
 					"requires": {
-						"ansi-styles": "1.0.0",
-						"has-color": "0.1.7",
-						"strip-ansi": "0.1.1"
+						"ansi-styles": "~1.0.0",
+						"has-color": "~0.1.0",
+						"strip-ansi": "~0.1.0"
 					}
 				},
 				"strip-ansi": {
@@ -6389,7 +8500,7 @@
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 			"requires": {
-				"abbrev": "1.0.9"
+				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -6397,10 +8508,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "2.5.0",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.4.1",
-				"validate-npm-package-license": "3.0.1"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"normalize-path": {
@@ -6408,7 +8519,7 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"requires": {
-				"remove-trailing-separator": "1.1.0"
+				"remove-trailing-separator": "^1.0.1"
 			}
 		},
 		"npm-run-path": {
@@ -6417,7 +8528,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "2.0.1"
+				"path-key": "^2.0.0"
 			}
 		},
 		"number-is-nan": {
@@ -6430,6 +8541,12 @@
 			"resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
 			"integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
 		},
+		"nwsapi": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.4.tgz",
+			"integrity": "sha512-Zt6HRR6RcJkuj5/N9zeE7FN6YitRW//hK2wTOwX274IBphbY3Zf5+yn5mZ9v/SzAOTMjQNxZf9KkmPLWn0cV4g==",
+			"dev": true
+		},
 		"oauth-sign": {
 			"version": "0.8.2",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -6440,13 +8557,85 @@
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
+		"object-copy": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
+			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
+			"dev": true,
+			"requires": {
+				"copy-descriptor": "^0.1.0",
+				"define-property": "^0.2.5",
+				"kind-of": "^3.0.3"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"object-keys": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+			"integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
+			"dev": true
+		},
+		"object-visit": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
+			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"es-abstract": "^1.5.1"
+			}
+		},
 		"object.omit": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"requires": {
-				"for-own": "0.1.5",
-				"is-extendable": "0.1.1"
+				"for-own": "^0.1.4",
+				"is-extendable": "^0.1.1"
+			}
+		},
+		"object.pick": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+			"dev": true,
+			"requires": {
+				"isobject": "^3.0.1"
+			},
+			"dependencies": {
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
 			}
 		},
 		"once": {
@@ -6454,12 +8643,12 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"onetime": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+			"resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
 			"integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
 		},
 		"optimist": {
@@ -6467,8 +8656,8 @@
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"requires": {
-				"minimist": "0.0.10",
-				"wordwrap": "0.0.2"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			},
 			"dependencies": {
 				"minimist": {
@@ -6483,12 +8672,12 @@
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"requires": {
-				"deep-is": "0.1.3",
-				"fast-levenshtein": "2.0.6",
-				"levn": "0.3.0",
-				"prelude-ls": "1.1.2",
-				"type-check": "0.3.2",
-				"wordwrap": "1.0.0"
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -6508,7 +8697,7 @@
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"requires": {
-				"lcid": "1.0.0"
+				"lcid": "^1.0.0"
 			}
 		},
 		"os-tmpdir": {
@@ -6521,16 +8710,10 @@
 			"resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
 			"integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"mkdirp": "0.5.1",
-				"object-assign": "4.1.1"
+				"graceful-fs": "^4.1.4",
+				"mkdirp": "^0.5.1",
+				"object-assign": "^4.1.0"
 			}
-		},
-		"p-cancelable": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.3.0.tgz",
-			"integrity": "sha512-RVbZPLso8+jFeq1MfNvgXtCRED2raz/dKpacfTNxsx6pLEpEomM7gah6VeHSYV3+vo0OAi4MkArtQcWWXuQoyw==",
-			"dev": true
 		},
 		"p-finally": {
 			"version": "1.0.0",
@@ -6539,10 +8722,13 @@
 			"dev": true
 		},
 		"p-limit": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-			"integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
-			"dev": true
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+			"dev": true,
+			"requires": {
+				"p-try": "^1.0.0"
+			}
 		},
 		"p-locate": {
 			"version": "2.0.0",
@@ -6550,18 +8736,24 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "1.1.0"
+				"p-limit": "^1.1.0"
 			}
+		},
+		"p-try": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+			"integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+			"dev": true
 		},
 		"parse-glob": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"requires": {
-				"glob-base": "0.3.0",
-				"is-dotfile": "1.0.3",
-				"is-extglob": "1.0.0",
-				"is-glob": "2.0.1"
+				"glob-base": "^0.3.0",
+				"is-dotfile": "^1.0.0",
+				"is-extglob": "^1.0.0",
+				"is-glob": "^2.0.0"
 			}
 		},
 		"parse-json": {
@@ -6569,7 +8761,7 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"requires": {
-				"error-ex": "1.3.1"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"parse5": {
@@ -6577,13 +8769,19 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
 			"integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ="
 		},
+		"pascalcase": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
+			"integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
+			"dev": true
+		},
 		"path": {
 			"version": "0.12.7",
 			"resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
 			"integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
 			"requires": {
-				"process": "0.11.10",
-				"util": "0.10.3"
+				"process": "^0.11.1",
+				"util": "^0.10.3"
 			}
 		},
 		"path-exists": {
@@ -6617,9 +8815,9 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"performance-now": {
@@ -6642,13 +8840,45 @@
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
+			}
+		},
+		"pkg-dir": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+			"dev": true,
+			"requires": {
+				"find-up": "^2.1.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+					"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+					"dev": true,
+					"requires": {
+						"locate-path": "^2.0.0"
+					}
+				}
 			}
 		},
 		"pluralize": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
 			"integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU="
+		},
+		"pn": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
+			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
+			"dev": true
+		},
+		"posix-character-classes": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
+			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
+			"dev": true
 		},
 		"prelude-ls": {
 			"version": "1.1.2",
@@ -6661,9 +8891,9 @@
 			"integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
 		},
 		"prettier": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.8.2.tgz",
-			"integrity": "sha512-fHWjCwoRZgjP1rvLP7OGqOznq7xH1sHMQUFLX8qLRO79hI57+6xbc5vB904LxEkCfgFgyr3vv06JkafgCSzoZg==",
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.6.tgz",
+			"integrity": "sha512-p5eqCNiohWZN++7aJXUVj0JgLqHCPLf9GLIcLBHGNWs4Y9FJOPs6+KNO2WT0udJIQJTbeZFrJkjzjcb8fkAYYQ==",
 			"dev": true
 		},
 		"pretty-format": {
@@ -6682,14 +8912,24 @@
 			"integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
 		},
 		"process-nextick-args": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-			"integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
 		},
 		"progress": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
 			"integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
+		},
+		"prompts": {
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/prompts/-/prompts-0.1.10.tgz",
+			"integrity": "sha512-/MPwms6+g/m6fvXZlQyOL4m4ziDim2+Wc6CdWVjp+nVCkzEkK2N4rR74m/bbGf+dkta+/SBpo1FfES8Wgrk/Fw==",
+			"dev": true,
+			"requires": {
+				"clorox": "^1.0.3",
+				"sisteransi": "^0.1.1"
+			}
 		},
 		"prr": {
 			"version": "0.0.0",
@@ -6721,8 +8961,8 @@
 			"resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
 			"integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
 			"requires": {
-				"is-number": "3.0.0",
-				"kind-of": "4.0.0"
+				"is-number": "^3.0.0",
+				"kind-of": "^4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -6730,7 +8970,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "3.2.2"
+						"kind-of": "^3.0.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6738,7 +8978,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "1.1.6"
+								"is-buffer": "^1.1.5"
 							}
 						}
 					}
@@ -6748,23 +8988,24 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "1.1.6"
+						"is-buffer": "^1.1.5"
 					}
 				}
 			}
 		},
 		"react-codemod": {
-			"version": "github:reactjs/react-codemod#f5a1282b80ab2280571a542e2ae98b91ca90a447",
+			"version": "github:reactjs/react-codemod#549dc17530770c4a91bfe3a64c25b420311d568d",
+			"from": "github:reactjs/react-codemod",
 			"requires": {
-				"babel-eslint": "6.1.2",
-				"babel-jest": "15.0.0",
-				"babel-plugin-transform-object-rest-spread": "6.26.0",
-				"babel-preset-es2015": "6.24.1",
-				"eslint": "2.13.1",
-				"fbjs-scripts": "0.7.1",
-				"jest": "17.0.3",
-				"jscodeshift": "0.3.32",
-				"path": "0.12.7"
+				"babel-eslint": "^6.0.5",
+				"babel-jest": "^15.0.0",
+				"babel-plugin-transform-object-rest-spread": "^6.6.5",
+				"babel-preset-es2015": "^6.6.0",
+				"eslint": "^2.13.1",
+				"fbjs-scripts": "^0.7.1",
+				"jest": "^17.0.3",
+				"jscodeshift": "^0.3.30",
+				"path": "^0.12.7"
 			},
 			"dependencies": {
 				"callsites": {
@@ -6782,9 +9023,9 @@
 					"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 					"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 					"requires": {
-						"string-width": "1.0.2",
-						"strip-ansi": "3.0.1",
-						"wrap-ansi": "2.1.0"
+						"string-width": "^1.0.1",
+						"strip-ansi": "^3.0.1",
+						"wrap-ansi": "^2.0.0"
 					}
 				},
 				"jest": {
@@ -6792,7 +9033,7 @@
 					"resolved": "https://registry.npmjs.org/jest/-/jest-17.0.3.tgz",
 					"integrity": "sha1-icQ7MLCqrUJGLp6nATUtrLrUo1Q=",
 					"requires": {
-						"jest-cli": "17.0.3"
+						"jest-cli": "^17.0.3"
 					},
 					"dependencies": {
 						"jest-cli": {
@@ -6800,36 +9041,59 @@
 							"resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-17.0.3.tgz",
 							"integrity": "sha1-cAuMAqnqDsnqsM1an9QtioWM4UY=",
 							"requires": {
-								"ansi-escapes": "1.4.0",
-								"callsites": "2.0.0",
-								"chalk": "1.1.3",
-								"graceful-fs": "4.1.11",
-								"is-ci": "1.0.10",
-								"istanbul-api": "1.2.1",
-								"istanbul-lib-coverage": "1.1.1",
-								"istanbul-lib-instrument": "1.9.1",
-								"jest-changed-files": "17.0.2",
-								"jest-config": "17.0.3",
-								"jest-environment-jsdom": "17.0.2",
-								"jest-file-exists": "17.0.0",
-								"jest-haste-map": "17.0.3",
-								"jest-jasmine2": "17.0.3",
-								"jest-mock": "17.0.2",
-								"jest-resolve": "17.0.3",
-								"jest-resolve-dependencies": "17.0.3",
-								"jest-runtime": "17.0.3",
-								"jest-snapshot": "17.0.3",
-								"jest-util": "17.0.2",
-								"json-stable-stringify": "1.0.1",
-								"node-notifier": "4.6.1",
-								"sane": "1.4.1",
-								"strip-ansi": "3.0.1",
-								"throat": "3.2.0",
-								"which": "1.3.0",
-								"worker-farm": "1.5.2",
-								"yargs": "6.6.0"
+								"ansi-escapes": "^1.4.0",
+								"callsites": "^2.0.0",
+								"chalk": "^1.1.1",
+								"graceful-fs": "^4.1.6",
+								"is-ci": "^1.0.9",
+								"istanbul-api": "^1.0.0-aplha.10",
+								"istanbul-lib-coverage": "^1.0.0",
+								"istanbul-lib-instrument": "^1.1.1",
+								"jest-changed-files": "^17.0.2",
+								"jest-config": "^17.0.3",
+								"jest-environment-jsdom": "^17.0.2",
+								"jest-file-exists": "^17.0.0",
+								"jest-haste-map": "^17.0.3",
+								"jest-jasmine2": "^17.0.3",
+								"jest-mock": "^17.0.2",
+								"jest-resolve": "^17.0.3",
+								"jest-resolve-dependencies": "^17.0.3",
+								"jest-runtime": "^17.0.3",
+								"jest-snapshot": "^17.0.3",
+								"jest-util": "^17.0.2",
+								"json-stable-stringify": "^1.0.0",
+								"node-notifier": "^4.6.1",
+								"sane": "~1.4.1",
+								"strip-ansi": "^3.0.1",
+								"throat": "^3.0.0",
+								"which": "^1.1.1",
+								"worker-farm": "^1.3.1",
+								"yargs": "^6.3.0"
 							}
 						}
+					}
+				},
+				"jscodeshift": {
+					"version": "0.3.32",
+					"resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.3.32.tgz",
+					"integrity": "sha1-3s5etgLxY0DY2VTH+WrJB8UC6rs=",
+					"requires": {
+						"async": "^1.5.0",
+						"babel-core": "^5",
+						"babel-plugin-transform-flow-strip-types": "^6.8.0",
+						"babel-preset-es2015": "^6.9.0",
+						"babel-preset-stage-1": "^6.5.0",
+						"babel-register": "^6.9.0",
+						"babylon": "^6.17.3",
+						"colors": "^1.1.2",
+						"flow-parser": "^0.*",
+						"lodash": "^4.13.1",
+						"micromatch": "^2.3.7",
+						"node-dir": "0.1.8",
+						"nomnom": "^1.8.1",
+						"recast": "^0.12.5",
+						"temp": "^0.8.1",
+						"write-file-atomic": "^1.2.0"
 					}
 				},
 				"yargs": {
@@ -6837,19 +9101,19 @@
 					"resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
 					"integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
 					"requires": {
-						"camelcase": "3.0.0",
-						"cliui": "3.2.0",
-						"decamelize": "1.2.0",
-						"get-caller-file": "1.0.2",
-						"os-locale": "1.4.0",
-						"read-pkg-up": "1.0.1",
-						"require-directory": "2.1.1",
-						"require-main-filename": "1.0.1",
-						"set-blocking": "2.0.0",
-						"string-width": "1.0.2",
-						"which-module": "1.0.0",
-						"y18n": "3.2.1",
-						"yargs-parser": "4.2.1"
+						"camelcase": "^3.0.0",
+						"cliui": "^3.2.0",
+						"decamelize": "^1.1.1",
+						"get-caller-file": "^1.0.1",
+						"os-locale": "^1.4.0",
+						"read-pkg-up": "^1.0.1",
+						"require-directory": "^2.1.1",
+						"require-main-filename": "^1.0.1",
+						"set-blocking": "^2.0.0",
+						"string-width": "^1.0.2",
+						"which-module": "^1.0.0",
+						"y18n": "^3.2.1",
+						"yargs-parser": "^4.2.0"
 					}
 				}
 			}
@@ -6859,9 +9123,9 @@
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"requires": {
-				"load-json-file": "1.1.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
+				"load-json-file": "^1.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -6869,22 +9133,22 @@
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-			"integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
-				"core-util-is": "1.0.2",
-				"inherits": "2.0.3",
-				"isarray": "1.0.0",
-				"process-nextick-args": "1.0.7",
-				"safe-buffer": "5.1.1",
-				"string_decoder": "1.0.3",
-				"util-deprecate": "1.0.2"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
 			}
 		},
 		"readline2": {
@@ -6892,9 +9156,18 @@
 			"resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
 			"integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
 			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
 				"mute-stream": "0.0.5"
+			}
+		},
+		"realpath-native": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/realpath-native/-/realpath-native-1.0.0.tgz",
+			"integrity": "sha512-XJtlRJ9jf0E1H1SLeJyQ9PGzQD7S65h1pRXEcAeK48doKOnKxcgPeNohJvD5u/2sI9J1oke6E8bZHS/fmW1UiQ==",
+			"dev": true,
+			"requires": {
+				"util.promisify": "^1.0.0"
 			}
 		},
 		"recast": {
@@ -6903,10 +9176,10 @@
 			"integrity": "sha512-y7ANxCWmMW8xLOaiopiRDlyjQ9ajKRENBH+2wjntIbk3A6ZR1+BLQttkmSHMY7Arl+AAZFwJ10grg2T6f1WI8A==",
 			"requires": {
 				"ast-types": "0.10.1",
-				"core-js": "2.5.1",
-				"esprima": "4.0.0",
-				"private": "0.1.8",
-				"source-map": "0.6.1"
+				"core-js": "^2.4.1",
+				"esprima": "~4.0.0",
+				"private": "~0.1.5",
+				"source-map": "~0.6.1"
 			},
 			"dependencies": {
 				"ast-types": {
@@ -6936,7 +9209,7 @@
 			"resolved": "https://registry.npmjs.org/redeyed/-/redeyed-1.0.1.tgz",
 			"integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
 			"requires": {
-				"esprima": "3.0.0"
+				"esprima": "~3.0.0"
 			},
 			"dependencies": {
 				"esprima": {
@@ -6956,12 +9229,12 @@
 			"resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
 			"integrity": "sha1-oORXxY69uuV1yfjNdRJ+k3VkNdg=",
 			"requires": {
-				"commoner": "0.10.8",
-				"defs": "1.1.1",
-				"esprima-fb": "15001.1001.0-dev-harmony-fb",
-				"private": "0.1.8",
+				"commoner": "~0.10.3",
+				"defs": "~1.1.0",
+				"esprima-fb": "~15001.1001.0-dev-harmony-fb",
+				"private": "~0.1.5",
 				"recast": "0.10.33",
-				"through": "2.3.8"
+				"through": "~2.3.8"
 			},
 			"dependencies": {
 				"ast-types": {
@@ -6969,15 +9242,20 @@
 					"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz",
 					"integrity": "sha1-oNkOQ1G7iHcWyD/WN+v4GK9K38w="
 				},
+				"esprima-fb": {
+					"version": "15001.1001.0-dev-harmony-fb",
+					"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+					"integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+				},
 				"recast": {
 					"version": "0.10.33",
 					"resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
 					"integrity": "sha1-lCgI96oBbx+nFCxGHX5XBKqo1pc=",
 					"requires": {
 						"ast-types": "0.8.12",
-						"esprima-fb": "15001.1001.0-dev-harmony-fb",
-						"private": "0.1.8",
-						"source-map": "0.5.7"
+						"esprima-fb": "~15001.1001.0-dev-harmony-fb",
+						"private": "~0.1.5",
+						"source-map": "~0.5.0"
 					}
 				}
 			}
@@ -6992,9 +9270,9 @@
 			"resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
 			"integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
 			"requires": {
-				"babel-runtime": "6.26.0",
-				"babel-types": "6.26.0",
-				"private": "0.1.8"
+				"babel-runtime": "^6.18.0",
+				"babel-types": "^6.19.0",
+				"private": "^0.1.6"
 			}
 		},
 		"regex-cache": {
@@ -7002,7 +9280,17 @@
 			"resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"requires": {
-				"is-equal-shallow": "0.1.3"
+				"is-equal-shallow": "^0.1.3"
+			}
+		},
+		"regex-not": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
+			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.2",
+				"safe-regex": "^1.1.0"
 			}
 		},
 		"regexpu": {
@@ -7010,11 +9298,11 @@
 			"resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
 			"integrity": "sha1-5TTcmRqeWEYFDJjebX3UpVyeoW0=",
 			"requires": {
-				"esprima": "2.7.3",
-				"recast": "0.10.43",
-				"regenerate": "1.3.3",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"esprima": "^2.6.0",
+				"recast": "^0.10.10",
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
 			},
 			"dependencies": {
 				"ast-types": {
@@ -7033,9 +9321,16 @@
 					"integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
 					"requires": {
 						"ast-types": "0.8.15",
-						"esprima-fb": "15001.1001.0-dev-harmony-fb",
-						"private": "0.1.8",
-						"source-map": "0.5.7"
+						"esprima-fb": "~15001.1001.0-dev-harmony-fb",
+						"private": "~0.1.5",
+						"source-map": "~0.5.0"
+					},
+					"dependencies": {
+						"esprima-fb": {
+							"version": "15001.1001.0-dev-harmony-fb",
+							"resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
+							"integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
+						}
 					}
 				}
 			}
@@ -7045,9 +9340,9 @@
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
 			"integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
 			"requires": {
-				"regenerate": "1.3.3",
-				"regjsgen": "0.2.0",
-				"regjsparser": "0.1.5"
+				"regenerate": "^1.2.1",
+				"regjsgen": "^0.2.0",
+				"regjsparser": "^0.1.4"
 			}
 		},
 		"regjsgen": {
@@ -7060,7 +9355,7 @@
 			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
 			"integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
 			"requires": {
-				"jsesc": "0.5.0"
+				"jsesc": "~0.5.0"
 			}
 		},
 		"remove-trailing-separator": {
@@ -7083,7 +9378,7 @@
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
 			"integrity": "sha1-PUEUIYh3U3SU+X93+Xhfq4EPpKw=",
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"replace-ext": {
@@ -7096,28 +9391,48 @@
 			"resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
 			"integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
 			"requires": {
-				"aws-sign2": "0.7.0",
-				"aws4": "1.6.0",
-				"caseless": "0.12.0",
-				"combined-stream": "1.0.5",
-				"extend": "3.0.1",
-				"forever-agent": "0.6.1",
-				"form-data": "2.3.1",
-				"har-validator": "5.0.3",
-				"hawk": "6.0.2",
-				"http-signature": "1.2.0",
-				"is-typedarray": "1.0.0",
-				"isstream": "0.1.2",
-				"json-stringify-safe": "5.0.1",
-				"mime-types": "2.1.17",
-				"oauth-sign": "0.8.2",
-				"performance-now": "2.1.0",
-				"qs": "6.5.1",
-				"safe-buffer": "5.1.1",
-				"stringstream": "0.0.5",
-				"tough-cookie": "2.3.3",
-				"tunnel-agent": "0.6.0",
-				"uuid": "3.1.0"
+				"aws-sign2": "~0.7.0",
+				"aws4": "^1.6.0",
+				"caseless": "~0.12.0",
+				"combined-stream": "~1.0.5",
+				"extend": "~3.0.1",
+				"forever-agent": "~0.6.1",
+				"form-data": "~2.3.1",
+				"har-validator": "~5.0.3",
+				"hawk": "~6.0.2",
+				"http-signature": "~1.2.0",
+				"is-typedarray": "~1.0.0",
+				"isstream": "~0.1.2",
+				"json-stringify-safe": "~5.0.1",
+				"mime-types": "~2.1.17",
+				"oauth-sign": "~0.8.2",
+				"performance-now": "^2.1.0",
+				"qs": "~6.5.1",
+				"safe-buffer": "^5.1.1",
+				"stringstream": "~0.0.5",
+				"tough-cookie": "~2.3.3",
+				"tunnel-agent": "^0.6.0",
+				"uuid": "^3.1.0"
+			}
+		},
+		"request-promise-core": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.13.1"
+			}
+		},
+		"request-promise-native": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
+			"integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+			"dev": true,
+			"requires": {
+				"request-promise-core": "1.1.1",
+				"stealthy-require": "^1.1.0",
+				"tough-cookie": ">=2.3.3"
 			}
 		},
 		"require-directory": {
@@ -7135,8 +9450,8 @@
 			"resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
 			"integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
 			"requires": {
-				"caller-path": "0.1.0",
-				"resolve-from": "1.0.1"
+				"caller-path": "^0.1.0",
+				"resolve-from": "^1.0.0"
 			}
 		},
 		"resolve": {
@@ -7144,7 +9459,24 @@
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
 			"integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
 			"requires": {
-				"path-parse": "1.0.5"
+				"path-parse": "^1.0.5"
+			}
+		},
+		"resolve-cwd": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+			"dev": true,
+			"requires": {
+				"resolve-from": "^3.0.0"
+			},
+			"dependencies": {
+				"resolve-from": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+					"integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+					"dev": true
+				}
 			}
 		},
 		"resolve-from": {
@@ -7152,21 +9484,33 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
 			"integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
 		},
+		"resolve-url": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+			"integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+			"dev": true
+		},
 		"restore-cursor": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 			"requires": {
-				"exit-hook": "1.1.1",
-				"onetime": "1.1.0"
+				"exit-hook": "^1.0.0",
+				"onetime": "^1.0.0"
 			}
+		},
+		"ret": {
+			"version": "0.1.15",
+			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+			"dev": true
 		},
 		"right-align": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
 			"integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
 			"requires": {
-				"align-text": "0.1.4"
+				"align-text": "^0.1.1"
 			}
 		},
 		"rimraf": {
@@ -7174,12 +9518,18 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
 			"integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI="
 		},
+		"rsvp": {
+			"version": "3.6.2",
+			"resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.6.2.tgz",
+			"integrity": "sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==",
+			"dev": true
+		},
 		"run-async": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
 			"integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
 			"requires": {
-				"once": "1.4.0"
+				"once": "^1.3.0"
 			}
 		},
 		"rx-lite": {
@@ -7192,17 +9542,26 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
 			"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
 		},
+		"safe-regex": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
+			"dev": true,
+			"requires": {
+				"ret": "~0.1.10"
+			}
+		},
 		"sane": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/sane/-/sane-1.4.1.tgz",
 			"integrity": "sha1-iPdj10BA9fDCVrYWPbOZvxEKxxU=",
 			"requires": {
-				"exec-sh": "0.2.1",
-				"fb-watchman": "1.9.2",
-				"minimatch": "3.0.4",
-				"minimist": "1.2.0",
-				"walker": "1.0.7",
-				"watch": "0.10.0"
+				"exec-sh": "^0.2.0",
+				"fb-watchman": "^1.8.0",
+				"minimatch": "^3.0.2",
+				"minimist": "^1.1.1",
+				"walker": "~1.0.5",
+				"watch": "~0.10.0"
 			},
 			"dependencies": {
 				"minimatch": {
@@ -7210,7 +9569,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "1.1.8"
+						"brace-expansion": "^1.1.7"
 					}
 				}
 			}
@@ -7230,13 +9589,36 @@
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
+		"set-value": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
+			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^2.0.1",
+				"is-extendable": "^0.1.1",
+				"is-plain-object": "^2.0.3",
+				"split-string": "^3.0.1"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
 		"shebang-command": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "1.0.0"
+				"shebang-regex": "^1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -7270,6 +9652,12 @@
 			"resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz",
 			"integrity": "sha1-Krt1qt453rXMgVzhDmGRFkhQuvA="
 		},
+		"sisteransi": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-0.1.1.tgz",
+			"integrity": "sha512-PmGOd02bM9YO5ifxpw36nrNMBTptEtfRl4qUYl9SndkolplkrZZOW7PGHjrZL53QvMVj9nQ+TKqUnRsw4tJa4g==",
+			"dev": true
+		},
 		"slash": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -7285,18 +9673,139 @@
 			"resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
 			"integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
 		},
+		"snapdragon": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
+			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+			"dev": true,
+			"requires": {
+				"base": "^0.11.1",
+				"debug": "^2.2.0",
+				"define-property": "^0.2.5",
+				"extend-shallow": "^2.0.1",
+				"map-cache": "^0.2.2",
+				"source-map": "^0.5.6",
+				"source-map-resolve": "^0.5.0",
+				"use": "^3.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				},
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				}
+			}
+		},
+		"snapdragon-node": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
+			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^1.0.0",
+				"isobject": "^3.0.0",
+				"snapdragon-util": "^3.0.1"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^1.0.0"
+					}
+				},
+				"is-accessor-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
+					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-data-descriptor": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
+					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+					"dev": true,
+					"requires": {
+						"kind-of": "^6.0.0"
+					}
+				},
+				"is-descriptor": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
+					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+					"dev": true,
+					"requires": {
+						"is-accessor-descriptor": "^1.0.0",
+						"is-data-descriptor": "^1.0.0",
+						"kind-of": "^6.0.2"
+					}
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				},
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
+		},
+		"snapdragon-util": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
+			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.2.0"
+			}
+		},
 		"sntp": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
 			"integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
 			"requires": {
-				"hoek": "4.2.0"
+				"hoek": "4.x.x"
 			}
 		},
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
 			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"source-map-resolve": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+			"dev": true,
+			"requires": {
+				"atob": "^2.1.1",
+				"decode-uri-component": "^0.2.0",
+				"resolve-url": "^0.2.1",
+				"source-map-url": "^0.4.0",
+				"urix": "^0.1.0"
+			}
 		},
 		"source-map-support": {
 			"version": "0.2.10",
@@ -7311,22 +9820,28 @@
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
 					"integrity": "sha1-yLbBZ3l7pHQKjqMyUhYv8IWRsmY=",
 					"requires": {
-						"amdefine": "1.0.1"
+						"amdefine": ">=0.0.4"
 					}
 				}
 			}
 		},
+		"source-map-url": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
+			"integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+			"dev": true
+		},
 		"sparkles": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-			"integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
+			"integrity": "sha512-dSO0DDYUahUt/0/pD/Is3VIm5TGJjludZ0HVymmhYF6eNA53PVLhnUk0znSYbH8IYBuJdCE+1luR22jNLMaQdw=="
 		},
 		"spdx-correct": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
 			"integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
 			"requires": {
-				"spdx-license-ids": "1.2.2"
+				"spdx-license-ids": "^1.0.2"
 			}
 		},
 		"spdx-expression-parse": {
@@ -7339,6 +9854,15 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
 			"integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
 		},
+		"split-string": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
+			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+			"dev": true,
+			"requires": {
+				"extend-shallow": "^3.0.0"
+			}
+		},
 		"sprintf-js": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -7349,20 +9873,53 @@
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
 			"integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
 			"requires": {
-				"asn1": "0.2.3",
-				"assert-plus": "1.0.0",
-				"bcrypt-pbkdf": "1.0.1",
-				"dashdash": "1.14.1",
-				"ecc-jsbn": "0.1.1",
-				"getpass": "0.1.7",
-				"jsbn": "0.1.1",
-				"tweetnacl": "0.14.5"
+				"asn1": "~0.2.3",
+				"assert-plus": "^1.0.0",
+				"bcrypt-pbkdf": "^1.0.0",
+				"dashdash": "^1.12.0",
+				"ecc-jsbn": "~0.1.1",
+				"getpass": "^0.1.1",
+				"jsbn": "~0.1.0",
+				"tweetnacl": "~0.14.0"
 			}
 		},
 		"stable": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.6.tgz",
-			"integrity": "sha1-kQ9dKu17Ugxud3SZwfMuE5/eyxA="
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+			"integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+		},
+		"stack-utils": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
+			"integrity": "sha1-1PM6tU6OOHeLDKXP07OvsS22hiA=",
+			"dev": true
+		},
+		"static-extend": {
+			"version": "0.1.2",
+			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
+			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
+			"dev": true,
+			"requires": {
+				"define-property": "^0.2.5",
+				"object-copy": "^0.1.0"
+			},
+			"dependencies": {
+				"define-property": {
+					"version": "0.2.5",
+					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
+					"dev": true,
+					"requires": {
+						"is-descriptor": "^0.1.0"
+					}
+				}
+			}
+		},
+		"stealthy-require": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+			"integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+			"dev": true
 		},
 		"string-length": {
 			"version": "2.0.0",
@@ -7370,8 +9927,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "1.0.0",
-				"strip-ansi": "4.0.0"
+				"astral-regex": "^1.0.0",
+				"strip-ansi": "^4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7386,7 +9943,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -7396,17 +9953,17 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"requires": {
-				"code-point-at": "1.1.0",
-				"is-fullwidth-code-point": "1.0.0",
-				"strip-ansi": "3.0.1"
+				"code-point-at": "^1.0.0",
+				"is-fullwidth-code-point": "^1.0.0",
+				"strip-ansi": "^3.0.0"
 			}
 		},
 		"string_decoder": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-			"integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"stringmap": {
@@ -7429,7 +9986,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "2.1.1"
+				"ansi-regex": "^2.0.0"
 			}
 		},
 		"strip-bom": {
@@ -7437,7 +9994,7 @@
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"requires": {
-				"is-utf8": "0.2.1"
+				"is-utf8": "^0.2.0"
 			}
 		},
 		"strip-eof": {
@@ -7466,12 +10023,12 @@
 			"resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
 			"integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
 			"requires": {
-				"ajv": "4.11.8",
-				"ajv-keywords": "1.5.1",
-				"chalk": "1.1.3",
-				"lodash": "4.17.4",
+				"ajv": "^4.7.0",
+				"ajv-keywords": "^1.0.0",
+				"chalk": "^1.1.1",
+				"lodash": "^4.0.0",
 				"slice-ansi": "0.0.4",
-				"string-width": "2.1.1"
+				"string-width": "^2.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7489,8 +10046,8 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"requires": {
-						"is-fullwidth-code-point": "2.0.0",
-						"strip-ansi": "4.0.0"
+						"is-fullwidth-code-point": "^2.0.0",
+						"strip-ansi": "^4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -7498,7 +10055,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
-						"ansi-regex": "3.0.0"
+						"ansi-regex": "^3.0.0"
 					}
 				}
 			}
@@ -7508,8 +10065,8 @@
 			"resolved": "https://registry.npmjs.org/temp/-/temp-0.8.3.tgz",
 			"integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
 			"requires": {
-				"os-tmpdir": "1.0.2",
-				"rimraf": "2.2.8"
+				"os-tmpdir": "^1.0.0",
+				"rimraf": "~2.2.6"
 			}
 		},
 		"test-exclude": {
@@ -7517,11 +10074,11 @@
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-2.1.3.tgz",
 			"integrity": "sha1-qNiWjh2oMmb5hk8oUsVeIg8GQ0o=",
 			"requires": {
-				"arrify": "1.0.1",
-				"micromatch": "2.3.11",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"require-main-filename": "1.0.1"
+				"arrify": "^1.0.1",
+				"micromatch": "^2.3.11",
+				"object-assign": "^4.1.0",
+				"read-pkg-up": "^1.0.1",
+				"require-main-filename": "^1.0.1"
 			}
 		},
 		"text-table": {
@@ -7544,8 +10101,8 @@
 			"resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"requires": {
-				"readable-stream": "2.3.3",
-				"xtend": "4.0.1"
+				"readable-stream": "^2.1.5",
+				"xtend": "~4.0.1"
 			}
 		},
 		"time-stamp": {
@@ -7563,12 +10120,54 @@
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
 			"integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
 		},
+		"to-object-path": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+			"dev": true,
+			"requires": {
+				"kind-of": "^3.0.2"
+			}
+		},
+		"to-regex": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
+			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+			"dev": true,
+			"requires": {
+				"define-property": "^2.0.2",
+				"extend-shallow": "^3.0.2",
+				"regex-not": "^1.0.2",
+				"safe-regex": "^1.1.0"
+			}
+		},
+		"to-regex-range": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+			"dev": true,
+			"requires": {
+				"is-number": "^3.0.0",
+				"repeat-string": "^1.6.1"
+			},
+			"dependencies": {
+				"is-number": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+					"dev": true,
+					"requires": {
+						"kind-of": "^3.0.2"
+					}
+				}
+			}
+		},
 		"tough-cookie": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
 			"integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
 			"requires": {
-				"punycode": "1.4.1"
+				"punycode": "^1.4.1"
 			}
 		},
 		"tr46": {
@@ -7586,11 +10185,6 @@
 			"resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz",
 			"integrity": "sha1-z95vq9ctY+V5fPqrhzq76OcA6RI="
 		},
-		"tryit": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
-			"integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics="
-		},
 		"tryor": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz",
@@ -7601,7 +10195,7 @@
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"requires": {
-				"safe-buffer": "5.1.1"
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"tweetnacl": {
@@ -7615,7 +10209,7 @@
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"requires": {
-				"prelude-ls": "1.1.2"
+				"prelude-ls": "~1.1.2"
 			}
 		},
 		"typedarray": {
@@ -7629,9 +10223,9 @@
 			"integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
 			"optional": true,
 			"requires": {
-				"source-map": "0.5.7",
-				"uglify-to-browserify": "1.0.2",
-				"yargs": "3.10.0"
+				"source-map": "~0.5.1",
+				"uglify-to-browserify": "~1.0.0",
+				"yargs": "~3.10.0"
 			},
 			"dependencies": {
 				"window-size": {
@@ -7646,9 +10240,9 @@
 					"integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
 					"optional": true,
 					"requires": {
-						"camelcase": "1.2.1",
-						"cliui": "2.1.0",
-						"decamelize": "1.2.0",
+						"camelcase": "^1.0.2",
+						"cliui": "^2.1.0",
+						"decamelize": "^1.0.0",
 						"window-size": "0.1.0"
 					}
 				}
@@ -7665,30 +10259,137 @@
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
 			"integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
 		},
+		"union-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
+			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+			"dev": true,
+			"requires": {
+				"arr-union": "^3.1.0",
+				"get-value": "^2.0.6",
+				"is-extendable": "^0.1.1",
+				"set-value": "^0.4.3"
+			},
+			"dependencies": {
+				"extend-shallow": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+					"dev": true,
+					"requires": {
+						"is-extendable": "^0.1.0"
+					}
+				},
+				"set-value": {
+					"version": "0.4.3",
+					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
+					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
+					"dev": true,
+					"requires": {
+						"extend-shallow": "^2.0.1",
+						"is-extendable": "^0.1.1",
+						"is-plain-object": "^2.0.1",
+						"to-object-path": "^0.3.0"
+					}
+				}
+			}
+		},
+		"unset-value": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
+			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
+			"dev": true,
+			"requires": {
+				"has-value": "^0.3.1",
+				"isobject": "^3.0.0"
+			},
+			"dependencies": {
+				"has-value": {
+					"version": "0.3.1",
+					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
+					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
+					"dev": true,
+					"requires": {
+						"get-value": "^2.0.3",
+						"has-values": "^0.1.4",
+						"isobject": "^2.0.0"
+					},
+					"dependencies": {
+						"isobject": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+							"integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+							"dev": true,
+							"requires": {
+								"isarray": "1.0.0"
+							}
+						}
+					}
+				},
+				"has-values": {
+					"version": "0.1.4",
+					"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
+					"integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
+					"dev": true
+				},
+				"isobject": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+					"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+					"dev": true
+				}
+			}
+		},
+		"urix": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+			"integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+			"dev": true
+		},
+		"use": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
+			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
+			"dev": true,
+			"requires": {
+				"kind-of": "^6.0.2"
+			},
+			"dependencies": {
+				"kind-of": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+					"integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+					"dev": true
+				}
+			}
+		},
 		"user-home": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
 			"integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA="
 		},
 		"util": {
-			"version": "0.10.3",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-			"integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+			"version": "0.10.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+			"integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
 			"requires": {
-				"inherits": "2.0.1"
-			},
-			"dependencies": {
-				"inherits": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-					"integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-				}
+				"inherits": "2.0.3"
 			}
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"util.promisify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
+			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.2",
+				"object.getownpropertydescriptors": "^2.0.3"
+			}
 		},
 		"uuid": {
 			"version": "3.1.0",
@@ -7700,8 +10401,8 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
 			"integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
 			"requires": {
-				"spdx-correct": "1.0.2",
-				"spdx-expression-parse": "1.0.4"
+				"spdx-correct": "~1.0.0",
+				"spdx-expression-parse": "~1.0.0"
 			}
 		},
 		"verror": {
@@ -7709,9 +10410,9 @@
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"requires": {
-				"assert-plus": "1.0.0",
+				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "1.3.0"
+				"extsprintf": "^1.2.0"
 			}
 		},
 		"vinyl": {
@@ -7719,9 +10420,18 @@
 			"resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
 			"integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
 			"requires": {
-				"clone": "1.0.3",
-				"clone-stats": "0.0.1",
+				"clone": "^1.0.0",
+				"clone-stats": "^0.0.1",
 				"replace-ext": "0.0.1"
+			}
+		},
+		"w3c-hr-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.1.tgz",
+			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
+			"dev": true,
+			"requires": {
+				"browser-process-hrtime": "^0.1.2"
 			}
 		},
 		"walker": {
@@ -7729,7 +10439,7 @@
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"requires": {
-				"makeerror": "1.0.11"
+				"makeerror": "1.0.x"
 			}
 		},
 		"watch": {
@@ -7750,13 +10460,19 @@
 				"iconv-lite": "0.4.19"
 			}
 		},
+		"whatwg-mimetype": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz",
+			"integrity": "sha512-FKxhYLytBQiUKjkYteN71fAUA3g6KpNXoho1isLiLSB3N1G4F35Q5vUxWfKFhBwi5IWF27VE6WxhrnnC+m0Mew==",
+			"dev": true
+		},
 		"whatwg-url": {
 			"version": "4.8.0",
 			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
 			"integrity": "sha1-0pgaqRSMHgCkHFphMRZqtGg7vMA=",
 			"requires": {
-				"tr46": "0.0.3",
-				"webidl-conversions": "3.0.1"
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
 			},
 			"dependencies": {
 				"webidl-conversions": {
@@ -7771,7 +10487,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
 			"integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"which-module": {
@@ -7794,8 +10510,8 @@
 			"resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.5.2.tgz",
 			"integrity": "sha512-XxiQ9kZN5n6mmnW+mFJ+wXjNNI/Nx4DIdaAKLX1Bn6LYBWlN/zaBhu34DQYPZ1AJobQuu67S2OfDdNSVULvXkQ==",
 			"requires": {
-				"errno": "0.1.4",
-				"xtend": "4.0.1"
+				"errno": "^0.1.4",
+				"xtend": "^4.0.1"
 			}
 		},
 		"wrap-ansi": {
@@ -7803,8 +10519,8 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
-				"string-width": "1.0.2",
-				"strip-ansi": "3.0.1"
+				"string-width": "^1.0.1",
+				"strip-ansi": "^3.0.1"
 			}
 		},
 		"wrappy": {
@@ -7817,7 +10533,7 @@
 			"resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
 			"integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
 			"requires": {
-				"mkdirp": "0.5.1"
+				"mkdirp": "^0.5.1"
 			}
 		},
 		"write-file-atomic": {
@@ -7825,9 +10541,19 @@
 			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
 			"integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"imurmurhash": "0.1.4",
-				"slide": "1.1.6"
+				"graceful-fs": "^4.1.11",
+				"imurmurhash": "^0.1.4",
+				"slide": "^1.1.5"
+			}
+		},
+		"ws": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-4.1.0.tgz",
+			"integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
+			"dev": true,
+			"requires": {
+				"async-limiter": "~1.0.0",
+				"safe-buffer": "~5.1.0"
 			}
 		},
 		"xml-name-validator": {
@@ -7855,12 +10581,12 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
 			"integrity": "sha1-ISBUaTFuk5Ex1Z8toMbX+YIh6kA=",
 			"requires": {
-				"camelcase": "1.2.1",
-				"cliui": "2.1.0",
-				"decamelize": "1.2.0",
-				"os-locale": "1.4.0",
-				"window-size": "0.1.4",
-				"y18n": "3.2.1"
+				"camelcase": "^1.2.1",
+				"cliui": "^2.1.0",
+				"decamelize": "^1.0.0",
+				"os-locale": "^1.4.0",
+				"window-size": "^0.1.2",
+				"y18n": "^3.2.0"
 			}
 		},
 		"yargs-parser": {
@@ -7868,7 +10594,7 @@
 			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
 			"integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
 			"requires": {
-				"camelcase": "3.0.0"
+				"camelcase": "^3.0.0"
 			},
 			"dependencies": {
 				"camelcase": {

--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
 	},
 	"homepage": "https://github.com/Automattic/calypso-codemods#readme",
 	"devDependencies": {
-		"jest": "^21.2.1",
-		"prettier": "^1.8.2"
+		"jest": "^23.2.0",
+		"prettier": "^1.13.6"
 	},
 	"dependencies": {
 		"5to6-codemod": "^1.7.1",
-		"jscodeshift": "^0.3.32",
-		"lodash": "^4.17.4",
-		"react-codemod": "reactjs/react-codemod"
+		"jscodeshift": "^0.5.1",
+		"lodash": "^4.17.10",
+		"react-codemod": "github:reactjs/react-codemod"
 	},
 	"jest": {
 		"setupFiles": [


### PR DESCRIPTION
Updated deps, hopefully to get rid of GitHub's security warnings about `hoek`. The update also updated `package.json` to NPM 6 format (probably).